### PR TITLE
(feat): start tutorials resource

### DIFF
--- a/tutorials/README.md
+++ b/tutorials/README.md
@@ -1,11 +1,7 @@
-# Community Resources for Agentic AI Red Teaming
+# Tutorials
 
-A curated, professional list of community resources to help practitioners plan, execute, and improve agentic AI red teaming efforts.
+Tutorials and standalone code samples for agentic AI red teaming. This directory hosts guides, walkthroughs, and reference material to help practitioners learn and apply red teaming techniques.
 
-## Playbooks & Guides
+## Contents
 
-| Resource | Description |
-| --- | --- |
-| [Pillar Security: Agentic AI Red Teaming Playbook](https://www.pillar.security/agentic-ai-red-teaming-playbook/) | End-to-end, battle-tested playbook that covers the full agentic AI red teaming methodology (recon to exploitation), focuses on actionable techniques and real-world scenarios, and centers risks at the agentic layer where models, tools, data, and workflows interact. |
-| [Joseph Thacker: How to Hack AI Agents and Applications](https://josephthacker.com/hacking/2025/02/25/how-to-hack-ai-apps.html) | Comprehensive guide that walks from understanding models to steering LLMs and then into AI attack scenarios, with a detailed methodology and attack pattern coverage for real applications. |
-| [Devansh: AI Pentest Scoping Playbook](https://devansh.bearblog.dev/ai-pentest-scoping/) | Practical scoping guide that explains how AI pentest scope differs from traditional web testing, maps layered attack surfaces (models, data pipelines, tools, agents, infrastructure), and outlines what to include in a thorough scope document. |
+- [Community Resources](community_resources.md) — A curated list of external playbooks, guides, and articles on agentic AI red teaming.

--- a/tutorials/community_resources.md
+++ b/tutorials/community_resources.md
@@ -1,0 +1,11 @@
+# Community Resources for Agentic AI Red Teaming
+
+A curated, professional list of community resources to help practitioners plan, execute, and improve agentic AI red teaming efforts.
+
+## Playbooks & Guides
+
+| Resource | Description |
+| --- | --- |
+| [Pillar Security: Agentic AI Red Teaming Playbook](https://www.pillar.security/agentic-ai-red-teaming-playbook/) | End-to-end, battle-tested playbook that covers the full agentic AI red teaming methodology (recon to exploitation), focuses on actionable techniques and real-world scenarios, and centers risks at the agentic layer where models, tools, data, and workflows interact. |
+| [Joseph Thacker: How to Hack AI Agents and Applications](https://josephthacker.com/hacking/2025/02/25/how-to-hack-ai-apps.html) | Comprehensive guide that walks from understanding models to steering LLMs and then into AI attack scenarios, with a detailed methodology and attack pattern coverage for real applications. |
+| [Devansh: AI Pentest Scoping Playbook](https://devansh.bearblog.dev/ai-pentest-scoping/) | Practical scoping guide that explains how AI pentest scope differs from traditional web testing, maps layered attack surfaces (models, data pipelines, tools, agents, infrastructure), and outlines what to include in a thorough scope document. |


### PR DESCRIPTION
Adds a new tutorials resource README that curates community playbooks and guides for agentic AI red teaming. This introduces an initial “Playbooks & Guides” table with three external references (Pillar Security playbook, Joseph Thacker guide, Devansh scoping playbook) and short descriptions to help practitioners plan, execute, and scope agentic AI red teaming efforts.