### PR TITLE
Config: Freeze agent0 image

### DIFF
--- a/exploitation/agent0/Makefile
+++ b/exploitation/agent0/Makefile
@@ -2,8 +2,8 @@ SANDBOX ?=
 SANDBOX_DIR := ../../sandboxes/$(SANDBOX)
 PROMPT_FILE ?=
 
-.PHONY: help run stop all check-sandbox setup-env lock sync prompt format \
-	prepare-settings convert-logs ui
+.PHONY: help run stop check-sandbox setup-env lock sync prompt format \
+	prepare-settings convert-logs ui all
 
 -include .env
 export
@@ -15,11 +15,11 @@ help: ## Display this help message
 	@echo ""
 	@echo "Available targets:"
 	@echo "  help                 Display this help message."
+	@echo "  all                  Run stop, run, and prompt in one shot."
 	@echo "  run                  Run the Red Team attack"
 	@echo "                       (starts sandbox and agent0)."
 	@echo "  stop                 Stop and remove the sandbox and agent0"
 	@echo "                       containers."
-	@echo "  all                  Clean, then run everything."
 	@echo "  prompt               Send a prompt to agent0"
 	@echo "                       (default: OWASP_Top10_LLM_App)."
 	@echo "                       Note: .md extension is optional."
@@ -52,14 +52,15 @@ prepare-settings:
 			"environment."; \
 		cp config/settings.json $(CURDIR)/tmp/settings.json; \
 	else \
-		sed 's/"api_keys": {}/"api_keys": {"google": \
-			"'$$GOOGLE_API_KEY'"}/' \
+		CLEAN_KEY=$$(echo "$$GOOGLE_API_KEY" | tr -d '"'); \
+		sed "s|\"api_keys\": {}|\"api_keys\": {\"google\": \"$$CLEAN_KEY\"}|" \
 			config/settings.json > $(CURDIR)/tmp/settings.json; \
 	fi
 	@echo "A0_PERSISTENT_RUNTIME_ID=automated_red_team" > $(CURDIR)/tmp/.env
 	@echo "AUTH_LOGIN=" >> $(CURDIR)/tmp/.env
 	@echo "AUTH_PASSWORD=" >> $(CURDIR)/tmp/.env
-	@echo "GOOGLE_API_KEY=$$GOOGLE_API_KEY" >> $(CURDIR)/tmp/.env
+	@CLEAN_KEY=$$(echo "$$GOOGLE_API_KEY" | tr -d '"'); \
+	echo "GOOGLE_API_KEY=$$CLEAN_KEY" >> $(CURDIR)/tmp/.env
 
 setup-env: sync lock prepare-settings
 
@@ -111,7 +112,7 @@ run: check-sandbox prepare-settings
 	@sleep 15
 	@echo "✅ Environment ready!"
 	@echo "Starting agent0 container..."
-	@podman pull agent0ai/agent-zero:latest
+	@podman pull agent0ai/agent-zero:v1.9
 	# Remove attacker if it already exists to avoid name conflict
 	-podman rm -f attacker 2>/dev/null || true
 	# Mount settings.json to /a0/tmp/settings.json because agent0 hardcodes it
@@ -123,7 +124,7 @@ run: check-sandbox prepare-settings
 		-p 50001:80 \
 		-v $(CURDIR)/tmp/settings.json:/a0/tmp/settings.json \
 		-v $(CURDIR)/tmp/.env:/a0/.env \
-		agent0ai/agent-zero:latest
+		agent0ai/agent-zero:v1.9
 	@echo "✅ agent0 started on http://localhost:50001"
 
 stop: check-sandbox
@@ -165,3 +166,5 @@ prompt: setup-env stop run
 			mv $$temp_file $$f; \
 		fi; \
 	done
+
+all: prompt

--- a/exploitation/agent0/README.md
+++ b/exploitation/agent0/README.md
@@ -119,11 +119,11 @@ The `Makefile` provides a set of high‑level commands that abstract away the lo
 
 ```bash
 # 2️⃣ Run the attack script (terminal mode)
-make prompt SANDBOX=llm_local PROMPT_FILE=prompt_1
+make all SANDBOX=llm_local PROMPT_FILE=prompt_1
 
-make prompt SANDBOX=llm_local PROMPT_FILE=prompt_2
+make all SANDBOX=llm_local PROMPT_FILE=prompt_2
 
-make prompt SANDBOX=llm_local PROMPT_FILE=prompt_3
+make all SANDBOX=llm_local PROMPT_FILE=prompt_3
 
 # (and so on)...
 ```
@@ -143,7 +143,7 @@ make ui
 
 **Why use the UI?**
 - Real‑time interaction mirrors a production chat client.
-- No need to re‑run `make prompt` for each tweak – just type a new message.
+- No need to re‑run `make all` for each tweak – just type a new message.
 - Visual feedback (agent thoughts, tool usage) helps debugging.
 
 ---

--- a/exploitation/agent0/run_agent.py
+++ b/exploitation/agent0/run_agent.py
@@ -57,7 +57,7 @@ def run_agent(url, api_key, prompt_file):
                     f"Sending prompt from {prompt_file} to {url} (Attempt {attempt + 1}/{max_retries})..."
                 )
                 response = requests.post(
-                    f"{url}/api_message", headers=headers, json=payload
+                    f"{url}/api/api_message", headers=headers, json=payload
                 )
                 response.raise_for_status()
 


### PR DESCRIPTION
Latest `agent0` image does not work on Mac m4-m5 processors using `podman`.

Reference: https://github.com/agent0ai/agent-zero/issues/1713

I pinned the `agent0` image version to the latest that works.

A few adaptations had to be made when upgrading the image from `v0.9.7` to `v1.9`.