### PR TITLE
fix(sandboxes): improve proxy and SSL support for uv and containerized services

### DIFF
--- a/sandboxes/RAG_local/Containerfile
+++ b/sandboxes/RAG_local/Containerfile
@@ -1,8 +1,10 @@
 FROM python:3.12-slim
 
 # Install uv (Python package manager)
-ENV PIP_ROOT_USER_ACTION=ignore
-RUN pip install --no-cache-dir uv
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
+
+# Allow connections through SSL-inspecting proxies
+ENV UV_INSECURE_HOST="pypi.org,files.pythonhosted.org"
 
 # Copy system requirements
 COPY packages.txt .

--- a/sandboxes/RAG_local/Makefile
+++ b/sandboxes/RAG_local/Makefile
@@ -116,6 +116,8 @@ run-gradio-headless: sync lock clean ollama-pull ollama-serve build up test test
 		-e OPENAI_BASE_URL="http://app_container:8000/v1" \
 		-e S3_BASE_URL="http://app_container:8000/s3" \
 		-e PINECONE_BASE_URL="http://app_container:8000/pinecone" \
+		-e NO_PROXY="host.containers.internal,app_container" \
+		-e no_proxy="host.containers.internal,app_container" \
 		--entrypoint uv \
 		app_container_build \
 		run python client/gradio_app.py

--- a/sandboxes/llm_local/Containerfile
+++ b/sandboxes/llm_local/Containerfile
@@ -1,8 +1,10 @@
 FROM python:3.12-slim
 
 # Install uv (Python package manager)
-ENV PIP_ROOT_USER_ACTION=ignore
-RUN pip install --no-cache-dir uv
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
+
+# Allow connections through SSL-inspecting proxies
+ENV UV_INSECURE_HOST="pypi.org,files.pythonhosted.org"
 
 # Copy system requirements
 COPY packages.txt .

--- a/sandboxes/llm_local/Makefile
+++ b/sandboxes/llm_local/Makefile
@@ -105,6 +105,8 @@ run-gradio-headless: sync lock clean ollama-pull ollama-serve build up test test
 		--network sec_test_net \
 		-p 7860:7860 \
 		-e OPENAI_BASE_URL="http://app_container:8000/v1" \
+		-e NO_PROXY="host.containers.internal,app_container" \
+		-e no_proxy="host.containers.internal,app_container" \
 		--entrypoint uv \
 		app_container_build \
 		run python client/gradio_app.py

--- a/sandboxes/llm_local_langchain_core_v1.2.4/Containerfile
+++ b/sandboxes/llm_local_langchain_core_v1.2.4/Containerfile
@@ -1,8 +1,10 @@
 FROM python:3.12-slim
 
 # Install uv (Python package manager)
-ENV PIP_ROOT_USER_ACTION=ignore
-RUN pip install --no-cache-dir uv
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
+
+# Allow connections through SSL-inspecting proxies
+ENV UV_INSECURE_HOST="pypi.org,files.pythonhosted.org"
 
 # Copy system requirements
 COPY packages.txt .

--- a/sandboxes/llm_local_langchain_core_v1.2.4/Makefile
+++ b/sandboxes/llm_local_langchain_core_v1.2.4/Makefile
@@ -105,6 +105,8 @@ run-gradio-headless: sync lock clean ollama-pull ollama-serve build up test test
 		-p 7860:7860 \
 		-e OPENAI_BASE_URL="http://app_container:8000/v1" \
 		-e FLAG="C0ngr4ts_y0u_f0und_m3" \
+		-e NO_PROXY="host.containers.internal,app_container" \
+		-e no_proxy="host.containers.internal,app_container" \
 		--entrypoint uv \
 		app_container_build \
 		run python client/gradio_app.py

--- a/sandboxes/llm_memory_local/Containerfile
+++ b/sandboxes/llm_memory_local/Containerfile
@@ -1,8 +1,10 @@
 FROM python:3.12-slim
 
 # Install uv (Python package manager)
-ENV PIP_ROOT_USER_ACTION=ignore
-RUN pip install --no-cache-dir uv
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
+
+# Allow connections through SSL-inspecting proxies
+ENV UV_INSECURE_HOST="pypi.org,files.pythonhosted.org"
 
 # Copy system requirements
 COPY packages.txt .

--- a/sandboxes/llm_memory_local/Makefile
+++ b/sandboxes/llm_memory_local/Makefile
@@ -117,6 +117,8 @@ run-gradio-headless: sync lock clean ollama-serve ollama-pull build up test test
 		--network mem_sec_test_net \
 		-p 7860:7860 \
 		-e OPENAI_BASE_URL="http://mem_app_container:8000/v1" \
+		-e NO_PROXY="host.containers.internal,mem_app_container" \
+		-e no_proxy="host.containers.internal,mem_app_container" \
 		--entrypoint uv \
 		mem_app_container_build \
 		run python client/gradio_app.py

--- a/sandboxes/llm_remote/Containerfile
+++ b/sandboxes/llm_remote/Containerfile
@@ -1,8 +1,10 @@
 FROM python:3.12-slim
 
 # Install uv (Python package manager)
-ENV PIP_ROOT_USER_ACTION=ignore
-RUN pip install --no-cache-dir uv
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
+
+# Allow connections through SSL-inspecting proxies
+ENV UV_INSECURE_HOST="pypi.org,files.pythonhosted.org"
 
 # Copy system requirements
 COPY packages.txt .

--- a/sandboxes/llm_remote/Makefile
+++ b/sandboxes/llm_remote/Makefile
@@ -131,6 +131,8 @@ run-gradio-headless: sync lock clean build up test
 		-p 7860:7860 \
 		-e SANDBOX_API_URL="http://$(CONTAINER_NAME):8000" \
 		-e SANDBOX_API_KEY="sk-mock-key" \
+		-e NO_PROXY="host.containers.internal,$(CONTAINER_NAME)" \
+		-e no_proxy="host.containers.internal,$(CONTAINER_NAME)" \
 		$(ENV_FILE_FLAG) \
 		$(ENV_FORWARD) \
 		--entrypoint uv \

--- a/sandboxes/mcp_local/Containerfile
+++ b/sandboxes/mcp_local/Containerfile
@@ -1,8 +1,10 @@
 FROM python:3.12-slim
 
 # Install uv (Python package manager)
-ENV PIP_ROOT_USER_ACTION=ignore
-RUN pip install --no-cache-dir uv
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
+
+# Allow connections through SSL-inspecting proxies
+ENV UV_INSECURE_HOST="pypi.org,files.pythonhosted.org"
 
 # Copy system requirements
 COPY packages.txt .

--- a/sandboxes/mcp_local/Makefile
+++ b/sandboxes/mcp_local/Makefile
@@ -118,6 +118,8 @@ run-gradio-headless: sync lock clean ollama-pull ollama-serve build up test test
 		--network sec_test_net \
 		-p 7860:7860 \
 		-e OPENAI_BASE_URL="http://app_container:8000/v1" \
+		-e NO_PROXY="host.containers.internal,app_container" \
+		-e no_proxy="host.containers.internal,app_container" \
 		--entrypoint uv \
 		app_container_build \
 		run python client/gradio_app.py


### PR DESCRIPTION
## Summary

This PR addresses package installation and proxy resolution issues when running sandboxes behind VPNs and network proxies:

1. **UV Multi-Stage Installation & SSL Proxy Support (`Containerfile`s):**
   - Replaced `pip install --no-cache-dir uv` across all sandbox `Containerfile`s with Astral's official Docker multi-stage binary copy: `COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/`.
   - Set `ENV UV_INSECURE_HOST="pypi.org,files.pythonhosted.org"` to allow package index metadata and wheel artifact downloads through SSL/TLS-inspecting proxies without certificate verification failures.

2. **Internal Bridge Network Proxy Bypass (`Makefile`s):**
   - Added `-e NO_PROXY="host.containers.internal,<target_container>"` and `-e no_proxy="host.containers.internal,<target_container>"` to `run-gradio-headless` in all sandbox Makefiles.
   - Prevents containerized client interfaces (Gradio) from erroneously attempting to route inter-container and host-directed requests through an external HTTP/HTTPS proxy.

## Modified Files
- `sandboxes/RAG_local/Containerfile`
- `sandboxes/llm_local/Containerfile`
- `sandboxes/llm_local_langchain_core_v1.2.4/Containerfile`
- `sandboxes/llm_memory_local/Containerfile`
- `sandboxes/llm_remote/Containerfile`
- `sandboxes/mcp_local/Containerfile`
- `sandboxes/RAG_local/Makefile`
- `sandboxes/llm_local/Makefile`
- `sandboxes/llm_local_langchain_core_v1.2.4/Makefile`
- `sandboxes/llm_memory_local/Makefile`
- `sandboxes/llm_remote/Makefile`
- `sandboxes/mcp_local/Makefile`