### PR TITLE
fix(garak): migrate deprecated probe_spec to run.spec

### DIFF
--- a/exploitation/garak/README.md
+++ b/exploitation/garak/README.md
@@ -111,17 +111,21 @@ sandbox = "llm_local"
 This file controls the Garak configuration. It defines which probes to run and how to report results.
 
 ```yaml
+run:
+  spec:
+    include:
+      - "probes.exploitation"
+
 plugins:
   target_type: "function"
   target_name: "integrate#generate"
-  probe_spec: "exploitation"
 
 reporting:
   report_prefix: "reports/GenAI-Red-Team"
   taxonomy: "owasp"
 ```
 
-- **`probe_spec`**: Determines which probes are active.
+- **`run.spec`**: Determines which probes are active. Entries must use the `probes.<name>` prefix (e.g., `probes.exploitation`). Run `uv run garak --list_probes` (or with `-v` for descriptions/tiers) to see available probes.
 - **`target_name`**: Points to the custom generator in `integrate.py`.
 
 ---

--- a/exploitation/garak/config/garak.yaml
+++ b/exploitation/garak/config/garak.yaml
@@ -11,55 +11,64 @@
 # List of probes to choose from
 # To obtain the most up-to-date list, run:
 #   uv run garak --list_probes
+# (or for descriptions & tiers: uv run garak --list_probes -v)
+# Note: In run.spec.include, probe names must be prefixed with "probes."
 # -----------------------------
-# probe_spec: "adaptive_attacks,\
-#   agent_breaker,\
-#   ansiescape,\
-#   apikey,\
-#   atkgen,\
-#   audio,\
-#   av_spam_scanning,\
-#   badchars,\
-#   continuation,\
-#   dan,\
-#   divergence,\
-#   doctor,\
-#   donotanswer,\
-#   dra,\
-#   encoding,\
-#   exploitation,\
-#   fileformats,\
-#   fitd,\
-#   glitch,\
-#   goat,\
-#   goodside,\
-#   grandma,\
-#   latentinjection,\
-#   leakreplay,\
-#   lmrc,\
-#   malwaregen,\
-#   misleading,\
-#   packagehallucination,\
-#   phrasing,\
-#   promptinject,\
-#   propile,\
-#   realtoxicityprompts,\
-#   sata,\
-#   smuggling,\
-#   snowball,\
-#   suffix,\
-#   sysprompt_extraction,\
-#   tap,\
-#   test,\
-#   topic,\
-#   visual_jailbreak,\
-#   web_injection"
+# run:
+#   spec:
+#     include:
+#       - "probes.adaptive_attacks"
+#       - "probes.agent_breaker"
+#       - "probes.ansiescape"
+#       - "probes.apikey"
+#       - "probes.atkgen"
+#       - "probes.audio"
+#       - "probes.av_spam_scanning"
+#       - "probes.badchars"
+#       - "probes.continuation"
+#       - "probes.dan"
+#       - "probes.divergence"
+#       - "probes.doctor"
+#       - "probes.donotanswer"
+#       - "probes.dra"
+#       - "probes.encoding"
+#       - "probes.exploitation"
+#       - "probes.fileformats"
+#       - "probes.fitd"
+#       - "probes.glitch"
+#       - "probes.goat"
+#       - "probes.goodside"
+#       - "probes.grandma"
+#       - "probes.latentinjection"
+#       - "probes.leakreplay"
+#       - "probes.lmrc"
+#       - "probes.malwaregen"
+#       - "probes.misleading"
+#       - "probes.packagehallucination"
+#       - "probes.phrasing"
+#       - "probes.promptinject"
+#       - "probes.propile"
+#       - "probes.realtoxicityprompts"
+#       - "probes.sata"
+#       - "probes.smuggling"
+#       - "probes.snowball"
+#       - "probes.suffix"
+#       - "probes.sysprompt_extraction"
+#       - "probes.tap"
+#       - "probes.test"
+#       - "probes.topic"
+#       - "probes.visual_jailbreak"
+#       - "probes.web_injection"
 # -----------------------------
+
+run:
+  spec:
+    include:
+      - "probes.exploitation"
 
 plugins:
   target_type: "function"
   target_name: "integrate#generate"
-  probe_spec: "exploitation"
 
 reporting:
   report_prefix: "reports/GenAI-Red-Team"


### PR DESCRIPTION
## Description

Migrate Garak probe configuration from the deprecated `plugins.probe_spec` to the modern unified specification syntax under `run.spec`.

In Garak >= 0.15.1, `plugins.probe_spec` is deprecated and produces:
```text
✋ DEPRECATION: config plugins.probe_spec is deprecated since version 0.15.1.pre1
```

## Changes

- **`exploitation/garak/config/garak.yaml`**:
  - Replaced `plugins.probe_spec: "exploitation"` with `run.spec.include: ["probes.exploitation"]`.
  - Updated the probe reference list comment and added notes regarding the required `probes.<name>` prefix and verbose listing command (`uv run garak --list_probes -v`).
- **`exploitation/garak/README.md`**:
  - Updated documentation examples and options to reference `run.spec`.

## Verification

- Tested `make setup` and verified container sandbox health.
- Verified config parsing with `uv run garak --config config/garak.yaml --list_config` (no deprecation warnings).
- Ran `make attack` and confirmed the scan executes without deprecation warnings.
- Ran `make format` (`black`, `isort`, `mypy`).